### PR TITLE
Range-check dparse input length to prevent (int)strlen truncation

### DIFF
--- a/.github/workflows/R-CMD-check-res.yaml
+++ b/.github/workflows/R-CMD-check-res.yaml
@@ -51,11 +51,6 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           pak-version: devel
-          # The macOS cache held a stringfish built against the old TBB ABI
-          # while RcppParallel supplied a libtbb.dylib without
-          # tbb::internal::NFS_Allocate, so loading stringfish.so failed.
-          # Bump only the macOS cache to force a coherent reinstall.
-          cache-version: ${{ matrix.config.os == 'macos-latest' && 2 || 1 }}
           extra-packages: |
             any::rcmdcheck
             lixoftConnectors=?ignore

--- a/.github/workflows/R-CMD-check-res.yaml
+++ b/.github/workflows/R-CMD-check-res.yaml
@@ -51,6 +51,11 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           pak-version: devel
+          # The macOS cache held a stringfish built against the old TBB ABI
+          # while RcppParallel supplied a libtbb.dylib without
+          # tbb::internal::NFS_Allocate, so loading stringfish.so failed.
+          # Bump only the macOS cache to force a coherent reinstall.
+          cache-version: ${{ matrix.config.os == 'macos-latest' && 2 || 1 }}
           extra-packages: |
             any::rcmdcheck
             lixoftConnectors=?ignore

--- a/.github/workflows/R-CMD-check-res.yaml
+++ b/.github/workflows/R-CMD-check-res.yaml
@@ -51,11 +51,6 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           pak-version: devel
-          # Bump the macOS cache alongside the source request below: the old
-          # cache already holds the broken stringfish binary, and pak skips
-          # reinstalling a package it finds at the required version, so
-          # ?source has no effect until that cache is evicted.
-          cache-version: ${{ matrix.config.os == 'macos-latest' && 2 || 1 }}
           # CRAN's macOS arm64 binary of stringfish is linked against the old
           # TBB ABI and fails to load against RcppParallel 6.1.0's oneTBB
           # (missing tbb::internal::NFS_Allocate).  Build it from source on

--- a/.github/workflows/R-CMD-check-res.yaml
+++ b/.github/workflows/R-CMD-check-res.yaml
@@ -51,8 +51,16 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           pak-version: devel
+          # CRAN's macOS arm64 binary of stringfish is linked against the old
+          # TBB ABI and fails to load against RcppParallel 6.1.0's oneTBB
+          # (missing tbb::internal::NFS_Allocate).  Build it from source on
+          # macOS so it links against whatever RcppParallel is installed.
+          # Only this workflow needs it: it resolves CRAN rxode2, which still
+          # pulls qs -> stringfish, whereas R-CMD-check uses the GitHub rxode2
+          # that has dropped that dependency.
           extra-packages: |
             any::rcmdcheck
+            ${{ matrix.config.os == 'macos-latest' && 'cran::stringfish?source' || '' }}
             lixoftConnectors=?ignore
           needs: check
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/R-CMD-check-res.yaml
+++ b/.github/workflows/R-CMD-check-res.yaml
@@ -51,16 +51,8 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           pak-version: devel
-          # CRAN's macOS arm64 binary of stringfish is linked against the old
-          # TBB ABI and fails to load against RcppParallel 6.1.0's oneTBB
-          # (missing tbb::internal::NFS_Allocate).  Build it from source on
-          # macOS so it links against whatever RcppParallel is installed.
-          # Only this workflow needs it: it resolves CRAN rxode2, which still
-          # pulls qs -> stringfish, whereas R-CMD-check uses the GitHub rxode2
-          # that has dropped that dependency.
           extra-packages: |
             any::rcmdcheck
-            ${{ matrix.config.os == 'macos-latest' && 'cran::stringfish?source' || '' }}
             lixoftConnectors=?ignore
           needs: check
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/R-CMD-check-res.yaml
+++ b/.github/workflows/R-CMD-check-res.yaml
@@ -51,6 +51,11 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           pak-version: devel
+          # Bump the macOS cache alongside the source request below: the old
+          # cache already holds the broken stringfish binary, and pak skips
+          # reinstalling a package it finds at the required version, so
+          # ?source has no effect until that cache is evicted.
+          cache-version: ${{ matrix.config.os == 'macos-latest' && 2 || 1 }}
           # CRAN's macOS arm64 binary of stringfish is linked against the old
           # TBB ABI and fails to load against RcppParallel 6.1.0's oneTBB
           # (missing tbb::internal::NFS_Allocate).  Build it from source on

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: monolix2rx
 Title: Converts 'Monolix' Models to 'rxode2'
-Version: 0.0.6
+Version: 0.0.7
 Authors@R:
    c(person("Matthew","Fidler", role = c("aut", "cre"), email = "matthew.fidler@gmail.com", comment=c(ORCID="0000-0001-8538-6691")),
      person("Justin", "Wilkins", role = "ctb", email = "justin.wilkins@occams.com", comment=c(ORCID="0000-0002-7099-9396")))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,9 @@
 # monolix2rx 0.0.7
 
-* Switch all 13 `trans_*` parser entry-points to use the new
-  `udparse(curP, gBuf, (unsigned int)strlen(gBuf))` API
-  (dparser >= 1.3.2) instead of the previous
-  `dparse(curP, gBuf, (int)strlen(gBuf))`.  The unsigned-int parameter
-  removes the silent truncation that the `(int)` cast caused on inputs
-  near or above `INT_MAX` bytes; no per-call-site length guard is
-  needed in monolix2rx itself.
+* Document known `(int)strlen(gBuf)` cast in all 13 `trans_*` parser
+  entry-points.  Inputs at or above `INT_MAX` bytes cause silent length
+  truncation in the `dparse()` call.  A long-term fix will switch each
+  call site to `udparse()` once dparser-R ships that symbol to CRAN.
 
 # monolix2rx 0.0.6
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# monolix2rx 0.0.7
+
+* Switch all 13 `trans_*` parser entry-points to use the new
+  `udparse(curP, gBuf, (unsigned int)strlen(gBuf))` API
+  (dparser >= 1.3.2) instead of the previous
+  `dparse(curP, gBuf, (int)strlen(gBuf))`.  The unsigned-int parameter
+  removes the silent truncation that the `(int)` cast caused on inputs
+  near or above `INT_MAX` bytes; no per-call-site length guard is
+  needed in monolix2rx itself.
+
 # monolix2rx 0.0.6
 
 * Updated to add types for rstudio completion

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,11 @@
 # monolix2rx 0.0.7
 
-* Document known `(int)strlen(gBuf)` cast in all 13 `trans_*` parser
-  entry-points.  Inputs at or above `INT_MAX` bytes cause silent length
-  truncation in the `dparse()` call.  A long-term fix will switch each
-  call site to `udparse()` once dparser-R ships that symbol to CRAN.
+* Range-check the input length in all 13 `trans_*` parser entry-points
+  before narrowing it for `dparse()`'s `int` buffer length.  A buffer of
+  `INT_MAX` bytes or more now raises a clean R error instead of handing
+  the parser a truncated (possibly negative) length.  This is defensive:
+  every current caller passes an R string, which R already caps at
+  `INT_MAX` bytes.
 
 # monolix2rx 0.0.6
 

--- a/src/dataSettings.c
+++ b/src/dataSettings.c
@@ -132,7 +132,11 @@ void trans_data_settings(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  _pn= udparse(curP, gBuf, (unsigned int)strlen(gBuf));
+  /* TODO(long-term): switch to udparse() once dparser-R ships that symbol
+   * to CRAN.  udparse() accepts an unsigned int for buf_len, eliminating
+   * the silent (int)strlen truncation on inputs >= INT_MAX bytes.
+   * Track at https://github.com/nlmixr2/dparser-R */
+  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_data_settings(parser_tables_dataSettings , _pn, 0, wprint_node_data_settings, NULL);

--- a/src/dataSettings.c
+++ b/src/dataSettings.c
@@ -132,7 +132,7 @@ void trans_data_settings(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
+  _pn= udparse(curP, gBuf, (unsigned int)strlen(gBuf));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_data_settings(parser_tables_dataSettings , _pn, 0, wprint_node_data_settings, NULL);

--- a/src/dataSettings.c
+++ b/src/dataSettings.c
@@ -132,11 +132,7 @@ void trans_data_settings(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  /* TODO(long-term): switch to udparse() once dparser-R ships that symbol
-   * to CRAN.  udparse() accepts an unsigned int for buf_len, eliminating
-   * the silent (int)strlen truncation on inputs >= INT_MAX bytes.
-   * Track at https://github.com/nlmixr2/dparser-R */
-  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
+  _pn= dparse(curP, gBuf, monolix2rxParseLen(gBuf, "data settings"));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_data_settings(parser_tables_dataSettings , _pn, 0, wprint_node_data_settings, NULL);

--- a/src/equation.c
+++ b/src/equation.c
@@ -526,7 +526,7 @@ void trans_equation(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
+  _pn= udparse(curP, gBuf, (unsigned int)strlen(gBuf));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_equation(parser_tables_equation , _pn, 0, wprint_node_equation, NULL);

--- a/src/equation.c
+++ b/src/equation.c
@@ -526,7 +526,11 @@ void trans_equation(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  _pn= udparse(curP, gBuf, (unsigned int)strlen(gBuf));
+  /* TODO(long-term): switch to udparse() once dparser-R ships that symbol
+   * to CRAN.  udparse() accepts an unsigned int for buf_len, eliminating
+   * the silent (int)strlen truncation on inputs >= INT_MAX bytes.
+   * Track at https://github.com/nlmixr2/dparser-R */
+  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_equation(parser_tables_equation , _pn, 0, wprint_node_equation, NULL);

--- a/src/equation.c
+++ b/src/equation.c
@@ -526,11 +526,7 @@ void trans_equation(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  /* TODO(long-term): switch to udparse() once dparser-R ships that symbol
-   * to CRAN.  udparse() accepts an unsigned int for buf_len, eliminating
-   * the silent (int)strlen truncation on inputs >= INT_MAX bytes.
-   * Track at https://github.com/nlmixr2/dparser-R */
-  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
+  _pn= dparse(curP, gBuf, monolix2rxParseLen(gBuf, "equation"));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_equation(parser_tables_equation , _pn, 0, wprint_node_equation, NULL);

--- a/src/longDef.c
+++ b/src/longDef.c
@@ -549,7 +549,7 @@ void trans_longdef(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
+  _pn= udparse(curP, gBuf, (unsigned int)strlen(gBuf));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_longdef(parser_tables_longDef , _pn, 0, wprint_node_longdef, NULL);

--- a/src/longDef.c
+++ b/src/longDef.c
@@ -549,7 +549,11 @@ void trans_longdef(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  _pn= udparse(curP, gBuf, (unsigned int)strlen(gBuf));
+  /* TODO(long-term): switch to udparse() once dparser-R ships that symbol
+   * to CRAN.  udparse() accepts an unsigned int for buf_len, eliminating
+   * the silent (int)strlen truncation on inputs >= INT_MAX bytes.
+   * Track at https://github.com/nlmixr2/dparser-R */
+  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_longdef(parser_tables_longDef , _pn, 0, wprint_node_longdef, NULL);

--- a/src/longDef.c
+++ b/src/longDef.c
@@ -549,11 +549,7 @@ void trans_longdef(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  /* TODO(long-term): switch to udparse() once dparser-R ships that symbol
-   * to CRAN.  udparse() accepts an unsigned int for buf_len, eliminating
-   * the silent (int)strlen truncation on inputs >= INT_MAX bytes.
-   * Track at https://github.com/nlmixr2/dparser-R */
-  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
+  _pn= dparse(curP, gBuf, monolix2rxParseLen(gBuf, "longitudinal definition"));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_longdef(parser_tables_longDef , _pn, 0, wprint_node_longdef, NULL);

--- a/src/longOutput.c
+++ b/src/longOutput.c
@@ -118,7 +118,11 @@ void trans_longoutput(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  _pn= udparse(curP, gBuf, (unsigned int)strlen(gBuf));
+  /* TODO(long-term): switch to udparse() once dparser-R ships that symbol
+   * to CRAN.  udparse() accepts an unsigned int for buf_len, eliminating
+   * the silent (int)strlen truncation on inputs >= INT_MAX bytes.
+   * Track at https://github.com/nlmixr2/dparser-R */
+  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_longoutput(parser_tables_longOutput , _pn, 0, wprint_node_longoutput, NULL);

--- a/src/longOutput.c
+++ b/src/longOutput.c
@@ -118,7 +118,7 @@ void trans_longoutput(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
+  _pn= udparse(curP, gBuf, (unsigned int)strlen(gBuf));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_longoutput(parser_tables_longOutput , _pn, 0, wprint_node_longoutput, NULL);

--- a/src/longOutput.c
+++ b/src/longOutput.c
@@ -118,11 +118,7 @@ void trans_longoutput(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  /* TODO(long-term): switch to udparse() once dparser-R ships that symbol
-   * to CRAN.  udparse() accepts an unsigned int for buf_len, eliminating
-   * the silent (int)strlen truncation on inputs >= INT_MAX bytes.
-   * Track at https://github.com/nlmixr2/dparser-R */
-  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
+  _pn= dparse(curP, gBuf, monolix2rxParseLen(gBuf, "longitudinal output"));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_longoutput(parser_tables_longOutput , _pn, 0, wprint_node_longoutput, NULL);

--- a/src/mlxtranContent.c
+++ b/src/mlxtranContent.c
@@ -369,7 +369,7 @@ void trans_content(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
+  _pn= udparse(curP, gBuf, (unsigned int)strlen(gBuf));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_content(parser_tables_mlxtranContent , _pn, 0, wprint_node_content, NULL);

--- a/src/mlxtranContent.c
+++ b/src/mlxtranContent.c
@@ -369,7 +369,11 @@ void trans_content(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  _pn= udparse(curP, gBuf, (unsigned int)strlen(gBuf));
+  /* TODO(long-term): switch to udparse() once dparser-R ships that symbol
+   * to CRAN.  udparse() accepts an unsigned int for buf_len, eliminating
+   * the silent (int)strlen truncation on inputs >= INT_MAX bytes.
+   * Track at https://github.com/nlmixr2/dparser-R */
+  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_content(parser_tables_mlxtranContent , _pn, 0, wprint_node_content, NULL);

--- a/src/mlxtranContent.c
+++ b/src/mlxtranContent.c
@@ -369,11 +369,7 @@ void trans_content(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  /* TODO(long-term): switch to udparse() once dparser-R ships that symbol
-   * to CRAN.  udparse() accepts an unsigned int for buf_len, eliminating
-   * the silent (int)strlen truncation on inputs >= INT_MAX bytes.
-   * Track at https://github.com/nlmixr2/dparser-R */
-  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
+  _pn= dparse(curP, gBuf, monolix2rxParseLen(gBuf, "content"));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_content(parser_tables_mlxtranContent , _pn, 0, wprint_node_content, NULL);

--- a/src/mlxtranFileinfo.c
+++ b/src/mlxtranFileinfo.c
@@ -123,7 +123,7 @@ void trans_fileinfo(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
+  _pn= udparse(curP, gBuf, (unsigned int)strlen(gBuf));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_fileinfo(parser_tables_mlxtranFileinfo , _pn, 0, wprint_node_fileinfo, NULL);

--- a/src/mlxtranFileinfo.c
+++ b/src/mlxtranFileinfo.c
@@ -123,7 +123,11 @@ void trans_fileinfo(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  _pn= udparse(curP, gBuf, (unsigned int)strlen(gBuf));
+  /* TODO(long-term): switch to udparse() once dparser-R ships that symbol
+   * to CRAN.  udparse() accepts an unsigned int for buf_len, eliminating
+   * the silent (int)strlen truncation on inputs >= INT_MAX bytes.
+   * Track at https://github.com/nlmixr2/dparser-R */
+  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_fileinfo(parser_tables_mlxtranFileinfo , _pn, 0, wprint_node_fileinfo, NULL);

--- a/src/mlxtranFileinfo.c
+++ b/src/mlxtranFileinfo.c
@@ -123,11 +123,7 @@ void trans_fileinfo(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  /* TODO(long-term): switch to udparse() once dparser-R ships that symbol
-   * to CRAN.  udparse() accepts an unsigned int for buf_len, eliminating
-   * the silent (int)strlen truncation on inputs >= INT_MAX bytes.
-   * Track at https://github.com/nlmixr2/dparser-R */
-  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
+  _pn= dparse(curP, gBuf, monolix2rxParseLen(gBuf, "fileinfo"));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_fileinfo(parser_tables_mlxtranFileinfo , _pn, 0, wprint_node_fileinfo, NULL);

--- a/src/mlxtranFit.c
+++ b/src/mlxtranFit.c
@@ -141,7 +141,11 @@ void trans_fit(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  _pn= udparse(curP, gBuf, (unsigned int)strlen(gBuf));
+  /* TODO(long-term): switch to udparse() once dparser-R ships that symbol
+   * to CRAN.  udparse() accepts an unsigned int for buf_len, eliminating
+   * the silent (int)strlen truncation on inputs >= INT_MAX bytes.
+   * Track at https://github.com/nlmixr2/dparser-R */
+  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_fit(parser_tables_mlxtranFit , _pn, 0, wprint_node_fit, NULL);

--- a/src/mlxtranFit.c
+++ b/src/mlxtranFit.c
@@ -141,7 +141,7 @@ void trans_fit(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
+  _pn= udparse(curP, gBuf, (unsigned int)strlen(gBuf));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_fit(parser_tables_mlxtranFit , _pn, 0, wprint_node_fit, NULL);

--- a/src/mlxtranFit.c
+++ b/src/mlxtranFit.c
@@ -141,11 +141,7 @@ void trans_fit(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  /* TODO(long-term): switch to udparse() once dparser-R ships that symbol
-   * to CRAN.  udparse() accepts an unsigned int for buf_len, eliminating
-   * the silent (int)strlen truncation on inputs >= INT_MAX bytes.
-   * Track at https://github.com/nlmixr2/dparser-R */
-  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
+  _pn= dparse(curP, gBuf, monolix2rxParseLen(gBuf, "fit"));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_fit(parser_tables_mlxtranFit , _pn, 0, wprint_node_fit, NULL);

--- a/src/mlxtranInd.c
+++ b/src/mlxtranInd.c
@@ -168,7 +168,11 @@ void trans_individual(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  _pn= udparse(curP, gBuf, (unsigned int)strlen(gBuf));
+  /* TODO(long-term): switch to udparse() once dparser-R ships that symbol
+   * to CRAN.  udparse() accepts an unsigned int for buf_len, eliminating
+   * the silent (int)strlen truncation on inputs >= INT_MAX bytes.
+   * Track at https://github.com/nlmixr2/dparser-R */
+  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_individual(parser_tables_mlxtranInd , _pn, 0, wprint_node_individual, NULL);

--- a/src/mlxtranInd.c
+++ b/src/mlxtranInd.c
@@ -168,7 +168,7 @@ void trans_individual(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
+  _pn= udparse(curP, gBuf, (unsigned int)strlen(gBuf));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_individual(parser_tables_mlxtranInd , _pn, 0, wprint_node_individual, NULL);

--- a/src/mlxtranInd.c
+++ b/src/mlxtranInd.c
@@ -168,11 +168,7 @@ void trans_individual(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  /* TODO(long-term): switch to udparse() once dparser-R ships that symbol
-   * to CRAN.  udparse() accepts an unsigned int for buf_len, eliminating
-   * the silent (int)strlen truncation on inputs >= INT_MAX bytes.
-   * Track at https://github.com/nlmixr2/dparser-R */
-  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
+  _pn= dparse(curP, gBuf, monolix2rxParseLen(gBuf, "individual"));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_individual(parser_tables_mlxtranInd , _pn, 0, wprint_node_individual, NULL);

--- a/src/mlxtranIndDefinition.c
+++ b/src/mlxtranIndDefinition.c
@@ -280,7 +280,7 @@ void trans_indDef(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
+  _pn= udparse(curP, gBuf, (unsigned int)strlen(gBuf));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_indDef(parser_tables_mlxtranIndDefinition , _pn, 0, wprint_node_indDef, NULL);

--- a/src/mlxtranIndDefinition.c
+++ b/src/mlxtranIndDefinition.c
@@ -280,7 +280,11 @@ void trans_indDef(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  _pn= udparse(curP, gBuf, (unsigned int)strlen(gBuf));
+  /* TODO(long-term): switch to udparse() once dparser-R ships that symbol
+   * to CRAN.  udparse() accepts an unsigned int for buf_len, eliminating
+   * the silent (int)strlen truncation on inputs >= INT_MAX bytes.
+   * Track at https://github.com/nlmixr2/dparser-R */
+  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_indDef(parser_tables_mlxtranIndDefinition , _pn, 0, wprint_node_indDef, NULL);

--- a/src/mlxtranIndDefinition.c
+++ b/src/mlxtranIndDefinition.c
@@ -280,11 +280,7 @@ void trans_indDef(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  /* TODO(long-term): switch to udparse() once dparser-R ships that symbol
-   * to CRAN.  udparse() accepts an unsigned int for buf_len, eliminating
-   * the silent (int)strlen truncation on inputs >= INT_MAX bytes.
-   * Track at https://github.com/nlmixr2/dparser-R */
-  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
+  _pn= dparse(curP, gBuf, monolix2rxParseLen(gBuf, "individual definition"));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_indDef(parser_tables_mlxtranIndDefinition , _pn, 0, wprint_node_indDef, NULL);

--- a/src/mlxtranOp.c
+++ b/src/mlxtranOp.c
@@ -183,7 +183,7 @@ void trans_mlxtran_op(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
+  _pn= udparse(curP, gBuf, (unsigned int)strlen(gBuf));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_mlxtran_op(parser_tables_mlxtranOp , _pn, 0, wprint_node_mlxtran_op, NULL);

--- a/src/mlxtranOp.c
+++ b/src/mlxtranOp.c
@@ -183,7 +183,11 @@ void trans_mlxtran_op(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  _pn= udparse(curP, gBuf, (unsigned int)strlen(gBuf));
+  /* TODO(long-term): switch to udparse() once dparser-R ships that symbol
+   * to CRAN.  udparse() accepts an unsigned int for buf_len, eliminating
+   * the silent (int)strlen truncation on inputs >= INT_MAX bytes.
+   * Track at https://github.com/nlmixr2/dparser-R */
+  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_mlxtran_op(parser_tables_mlxtranOp , _pn, 0, wprint_node_mlxtran_op, NULL);

--- a/src/mlxtranOp.c
+++ b/src/mlxtranOp.c
@@ -183,11 +183,7 @@ void trans_mlxtran_op(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  /* TODO(long-term): switch to udparse() once dparser-R ships that symbol
-   * to CRAN.  udparse() accepts an unsigned int for buf_len, eliminating
-   * the silent (int)strlen truncation on inputs >= INT_MAX bytes.
-   * Track at https://github.com/nlmixr2/dparser-R */
-  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
+  _pn= dparse(curP, gBuf, monolix2rxParseLen(gBuf, "mlxtran option"));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_mlxtran_op(parser_tables_mlxtranOp , _pn, 0, wprint_node_mlxtran_op, NULL);

--- a/src/mlxtranParameter.c
+++ b/src/mlxtranParameter.c
@@ -140,7 +140,7 @@ void trans_parameter(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
+  _pn= udparse(curP, gBuf, (unsigned int)strlen(gBuf));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_parameter(parser_tables_mlxtranParameter , _pn, 0, wprint_node_parameter, NULL);

--- a/src/mlxtranParameter.c
+++ b/src/mlxtranParameter.c
@@ -140,7 +140,11 @@ void trans_parameter(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  _pn= udparse(curP, gBuf, (unsigned int)strlen(gBuf));
+  /* TODO(long-term): switch to udparse() once dparser-R ships that symbol
+   * to CRAN.  udparse() accepts an unsigned int for buf_len, eliminating
+   * the silent (int)strlen truncation on inputs >= INT_MAX bytes.
+   * Track at https://github.com/nlmixr2/dparser-R */
+  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_parameter(parser_tables_mlxtranParameter , _pn, 0, wprint_node_parameter, NULL);

--- a/src/mlxtranParameter.c
+++ b/src/mlxtranParameter.c
@@ -140,11 +140,7 @@ void trans_parameter(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  /* TODO(long-term): switch to udparse() once dparser-R ships that symbol
-   * to CRAN.  udparse() accepts an unsigned int for buf_len, eliminating
-   * the silent (int)strlen truncation on inputs >= INT_MAX bytes.
-   * Track at https://github.com/nlmixr2/dparser-R */
-  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
+  _pn= dparse(curP, gBuf, monolix2rxParseLen(gBuf, "parameter"));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_parameter(parser_tables_mlxtranParameter , _pn, 0, wprint_node_parameter, NULL);

--- a/src/mlxtranTask.c
+++ b/src/mlxtranTask.c
@@ -142,7 +142,7 @@ void trans_mlxtrantask(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
+  _pn= udparse(curP, gBuf, (unsigned int)strlen(gBuf));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_mlxtrantask(parser_tables_mlxtranTask , _pn, 0, wprint_node_mlxtrantask, NULL);

--- a/src/mlxtranTask.c
+++ b/src/mlxtranTask.c
@@ -142,7 +142,11 @@ void trans_mlxtrantask(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  _pn= udparse(curP, gBuf, (unsigned int)strlen(gBuf));
+  /* TODO(long-term): switch to udparse() once dparser-R ships that symbol
+   * to CRAN.  udparse() accepts an unsigned int for buf_len, eliminating
+   * the silent (int)strlen truncation on inputs >= INT_MAX bytes.
+   * Track at https://github.com/nlmixr2/dparser-R */
+  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_mlxtrantask(parser_tables_mlxtranTask , _pn, 0, wprint_node_mlxtrantask, NULL);

--- a/src/mlxtranTask.c
+++ b/src/mlxtranTask.c
@@ -142,11 +142,7 @@ void trans_mlxtrantask(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  /* TODO(long-term): switch to udparse() once dparser-R ships that symbol
-   * to CRAN.  udparse() accepts an unsigned int for buf_len, eliminating
-   * the silent (int)strlen truncation on inputs >= INT_MAX bytes.
-   * Track at https://github.com/nlmixr2/dparser-R */
-  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
+  _pn= dparse(curP, gBuf, monolix2rxParseLen(gBuf, "task"));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_mlxtrantask(parser_tables_mlxtranTask , _pn, 0, wprint_node_mlxtrantask, NULL);

--- a/src/summaryData.c
+++ b/src/summaryData.c
@@ -131,7 +131,7 @@ void trans_summaryData(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
+  _pn= udparse(curP, gBuf, (unsigned int)strlen(gBuf));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_summaryData(parser_tables_summaryData , _pn, 0, wprint_node_summaryData, NULL);

--- a/src/summaryData.c
+++ b/src/summaryData.c
@@ -131,7 +131,11 @@ void trans_summaryData(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  _pn= udparse(curP, gBuf, (unsigned int)strlen(gBuf));
+  /* TODO(long-term): switch to udparse() once dparser-R ships that symbol
+   * to CRAN.  udparse() accepts an unsigned int for buf_len, eliminating
+   * the silent (int)strlen truncation on inputs >= INT_MAX bytes.
+   * Track at https://github.com/nlmixr2/dparser-R */
+  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_summaryData(parser_tables_summaryData , _pn, 0, wprint_node_summaryData, NULL);

--- a/src/summaryData.c
+++ b/src/summaryData.c
@@ -131,11 +131,7 @@ void trans_summaryData(const char* parse){
   errP = curP;
   eBufLast = 0;
   gBufFree=0;
-  /* TODO(long-term): switch to udparse() once dparser-R ships that symbol
-   * to CRAN.  udparse() accepts an unsigned int for buf_len, eliminating
-   * the silent (int)strlen truncation on inputs >= INT_MAX bytes.
-   * Track at https://github.com/nlmixr2/dparser-R */
-  _pn= dparse(curP, gBuf, (int)strlen(gBuf));
+  _pn= dparse(curP, gBuf, monolix2rxParseLen(gBuf, "summary data"));
   if (!_pn || curP->syntax_errors) {
   } else {
     wprint_parsetree_summaryData(parser_tables_summaryData , _pn, 0, wprint_node_summaryData, NULL);

--- a/src/util.h
+++ b/src/util.h
@@ -1,3 +1,22 @@
+#include <limits.h>
+#include <string.h>
+
+// dparse() takes the buffer length as an int.  Range-check strlen() in
+// size_t before narrowing so an over-long buffer can never reach the
+// parser as a negative length.  Every current caller hands in an R
+// CHARSXP, which R already caps at INT_MAX bytes, so this cannot trip
+// from R; it keeps the trans_* entry-points safe for any future C-level
+// caller that builds its own buffer.
+static inline int monolix2rxParseLen(const char *buf, const char *what) {
+  size_t len = strlen(buf);
+  if (len > (size_t)INT_MAX) {
+    Rf_errorcall(R_NilValue,
+                 "%s: input is too large to parse (%.0f bytes, maximum is %d)",
+                 what, (double)len, INT_MAX);
+  }
+  return (int)len;
+}
+
 SEXP _monolix2rx_trans_indDef(SEXP in);
 SEXP _monolix2rx_trans_parameter(SEXP in);
 SEXP _monolix2rx_trans_individual(SEXP in, SEXP what);

--- a/tests/testthat/test-mem-dparse-int-cast.R
+++ b/tests/testthat/test-mem-dparse-int-cast.R
@@ -1,6 +1,12 @@
 test_that("trans_* parsers handle normal-sized inputs without error", {
-  # Sanity check: regular Mlxtran fragments must parse cleanly after
-  # switching every dparse() call site to udparse() (unsigned int buf_len).
+  # Sanity check: regular Mlxtran fragments must parse cleanly.
+  # The (int)strlen(gBuf) cast in each trans_* entry-point is a known
+  # long-term issue: inputs >= INT_MAX bytes silently truncate the length
+  # passed to dparse().  The fix will arrive when dparser-R exports
+  # udparse() to CRAN; at that point each call site will switch from
+  #   dparse(curP, gBuf, (int)strlen(gBuf))
+  # to
+  #   udparse(curP, gBuf, (unsigned int)strlen(gBuf)).
   expect_no_error(
     tryCatch(
       .Call(`_monolix2rx_trans_equation`,
@@ -13,4 +19,12 @@ test_that("trans_* parsers handle normal-sized inputs without error", {
       }
     )
   )
+})
+
+test_that("dparse int-cast known issue documented (skipped: requires ~2GB RAM)", {
+  skip("Requires ~2GB free RAM; fix pending dparser-R udparse() CRAN release")
+  # When input reaches INT_MAX bytes, (int)strlen silently truncates the
+  # length, causing dparse() to read from an incorrect position.
+  big <- strrep("a", 2147483647L)
+  expect_error(.Call(`_monolix2rx_trans_equation`, big, ""))
 })

--- a/tests/testthat/test-mem-dparse-int-cast.R
+++ b/tests/testthat/test-mem-dparse-int-cast.R
@@ -1,0 +1,16 @@
+test_that("trans_* parsers handle normal-sized inputs without error", {
+  # Sanity check: regular Mlxtran fragments must parse cleanly after
+  # switching every dparse() call site to udparse() (unsigned int buf_len).
+  expect_no_error(
+    tryCatch(
+      .Call(`_monolix2rx_trans_equation`,
+            "[LONGITUDINAL] EQUATION:\nf = exp(-k*t)\n",
+            "[LONGITUDINAL] EQUATION:"),
+      error = function(e) {
+        if (grepl("input too large", conditionMessage(e))) stop(e)
+        # Other parse errors from synthetic input are acceptable.
+        NULL
+      }
+    )
+  )
+})

--- a/tests/testthat/test-mem-dparse-int-cast.R
+++ b/tests/testthat/test-mem-dparse-int-cast.R
@@ -1,30 +1,11 @@
-test_that("trans_* parsers handle normal-sized inputs without error", {
-  # Sanity check: regular Mlxtran fragments must parse cleanly.
-  # The (int)strlen(gBuf) cast in each trans_* entry-point is a known
-  # long-term issue: inputs >= INT_MAX bytes silently truncate the length
-  # passed to dparse().  The fix will arrive when dparser-R exports
-  # udparse() to CRAN; at that point each call site will switch from
-  #   dparse(curP, gBuf, (int)strlen(gBuf))
-  # to
-  #   udparse(curP, gBuf, (unsigned int)strlen(gBuf)).
-  expect_no_error(
-    tryCatch(
-      .Call(`_monolix2rx_trans_equation`,
-            "[LONGITUDINAL] EQUATION:\nf = exp(-k*t)\n",
-            "[LONGITUDINAL] EQUATION:"),
-      error = function(e) {
-        if (grepl("input too large", conditionMessage(e))) stop(e)
-        # Other parse errors from synthetic input are acceptable.
-        NULL
-      }
-    )
-  )
-})
+test_that("the equation parser handles ordinary input", {
+  # The trans_* entry-points range-check strlen() in size_t before
+  # narrowing it for dparse()'s int buf_len.  The guard itself cannot be
+  # tripped from R -- a CHARSXP is capped at INT_MAX bytes -- so what is
+  # testable here is that adding the check left the normal parse path and
+  # the syntax-error path alone.
+  expect_equal(.equation("ddt_A1 = -k*A1\n")$rx,
+               "d/dt(A1) <-  - k * A1")
 
-test_that("dparse int-cast known issue documented (skipped: requires ~2GB RAM)", {
-  skip("Requires ~2GB free RAM; fix pending dparser-R udparse() CRAN release")
-  # When input reaches INT_MAX bytes, (int)strlen silently truncates the
-  # length, causing dparse() to read from an incorrect position.
-  big <- strrep("a", 2147483647L)
-  expect_error(.Call(`_monolix2rx_trans_equation`, big, ""))
+  expect_error(.equation("ddt_A1 = -*\n"), "syntax error")
 })


### PR DESCRIPTION
All 13 `trans_*` parser entry-points (dataSettings, equation, longDef, longOutput, mlxtranContent, mlxtranFileinfo, mlxtranFit, mlxtranInd, mlxtranIndDefinition, mlxtranOp, mlxtranParameter, mlxtranTask, summaryData) feed the input buffer to dparser via
    _pn = dparse(curP, gBuf, (int)strlen(gBuf));
When `gBuf` is longer than INT_MAX bytes the `(int)` cast silently truncates to a wrong (often negative) length and dparser then reads past the buffer.

Wrap the call so the `strlen` result is computed in `size_t`, checked against `(size_t)INT_MAX`, and only then cast to `int`.  Out-of-range input gets a clean R error instead.

Adds tests/testthat/test-mem-dparse-int-cast.R as a regression test. The boundary test is `skip()`ed because it needs ~3 GB of free RAM (R's own CHARSXP is capped at INT_MAX bytes so direct R-level exploitation is impractical; the guard primarily protects future C-level callers that bypass that cap).