### PR TITLE
Update vdiffr snapshots for R 4.6 / ggplot2 4.0 rendering

### DIFF
--- a/tests/testthat/_snaps/data-import/multiple-endpoint-theo-p1.svg
+++ b/tests/testthat/_snaps/data-import/multiple-endpoint-theo-p1.svg
@@ -535,117 +535,198 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMzMuNzh8MjU3LjA0fDM4Ny4wNnw0MjEuNjc='>
-    <rect x='33.78' y='387.06' width='223.26' height='34.61' />
+  <clipPath id='cpMzMuNzh8MjU3LjA0fDM4Ny4wNnw0MDQuMzc='>
+    <rect x='33.78' y='387.06' width='223.26' height='17.30' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzMuNzh8MjU3LjA0fDM4Ny4wNnw0MjEuNjc=)'>
+<g clip-path='url(#cpMzMuNzh8MjU3LjA0fDM4Ny4wNnw0MDQuMzc=)'>
 <rect x='33.78' y='387.06' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='145.41' y='400.26' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='38.17px' lengthAdjust='spacingAndGlyphs'>y1_Cp</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMzMuNzh8MjU3LjA0fDQwNC4zN3w0MjEuNjc='>
+    <rect x='33.78' y='404.37' width='223.26' height='17.30' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzMuNzh8MjU3LjA0fDQwNC4zN3w0MjEuNjc=)'>
 <rect x='33.78' y='404.37' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='145.41' y='417.56' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='7.34px' lengthAdjust='spacingAndGlyphs'>7</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMjYyLjUyfDQ4NS43OHwzODcuMDZ8NDIxLjY3'>
-    <rect x='262.52' y='387.06' width='223.26' height='34.61' />
+  <clipPath id='cpMjYyLjUyfDQ4NS43OHwzODcuMDZ8NDA0LjM3'>
+    <rect x='262.52' y='387.06' width='223.26' height='17.30' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjYyLjUyfDQ4NS43OHwzODcuMDZ8NDIxLjY3)'>
+<g clip-path='url(#cpMjYyLjUyfDQ4NS43OHwzODcuMDZ8NDA0LjM3)'>
 <rect x='262.52' y='387.06' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='374.15' y='400.26' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='38.17px' lengthAdjust='spacingAndGlyphs'>y1_Cp</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjYyLjUyfDQ4NS43OHw0MDQuMzd8NDIxLjY3'>
+    <rect x='262.52' y='404.37' width='223.26' height='17.30' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjYyLjUyfDQ4NS43OHw0MDQuMzd8NDIxLjY3)'>
 <rect x='262.52' y='404.37' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='374.15' y='417.56' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='7.34px' lengthAdjust='spacingAndGlyphs'>8</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNDkxLjI2fDcxNC41MnwzODcuMDZ8NDIxLjY3'>
-    <rect x='491.26' y='387.06' width='223.26' height='34.61' />
+  <clipPath id='cpNDkxLjI2fDcxNC41MnwzODcuMDZ8NDA0LjM3'>
+    <rect x='491.26' y='387.06' width='223.26' height='17.30' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNDkxLjI2fDcxNC41MnwzODcuMDZ8NDIxLjY3)'>
+<g clip-path='url(#cpNDkxLjI2fDcxNC41MnwzODcuMDZ8NDA0LjM3)'>
 <rect x='491.26' y='387.06' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='602.89' y='400.26' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='38.17px' lengthAdjust='spacingAndGlyphs'>y1_Cp</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDkxLjI2fDcxNC41Mnw0MDQuMzd8NDIxLjY3'>
+    <rect x='491.26' y='404.37' width='223.26' height='17.30' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDkxLjI2fDcxNC41Mnw0MDQuMzd8NDIxLjY3)'>
 <rect x='491.26' y='404.37' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='602.89' y='417.56' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='7.34px' lengthAdjust='spacingAndGlyphs'>9</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMzMuNzh8MjU3LjA0fDIyNC41MnwyNTkuMTM='>
-    <rect x='33.78' y='224.52' width='223.26' height='34.61' />
+  <clipPath id='cpMzMuNzh8MjU3LjA0fDIyNC41MnwyNDEuODM='>
+    <rect x='33.78' y='224.52' width='223.26' height='17.30' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzMuNzh8MjU3LjA0fDIyNC41MnwyNTkuMTM=)'>
+<g clip-path='url(#cpMzMuNzh8MjU3LjA0fDIyNC41MnwyNDEuODM=)'>
 <rect x='33.78' y='224.52' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='145.41' y='237.72' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='38.17px' lengthAdjust='spacingAndGlyphs'>y1_Cp</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMzMuNzh8MjU3LjA0fDI0MS44M3wyNTkuMTM='>
+    <rect x='33.78' y='241.83' width='223.26' height='17.30' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzMuNzh8MjU3LjA0fDI0MS44M3wyNTkuMTM=)'>
 <rect x='33.78' y='241.83' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='145.41' y='255.02' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='7.34px' lengthAdjust='spacingAndGlyphs'>4</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMjYyLjUyfDQ4NS43OHwyMjQuNTJ8MjU5LjEz'>
-    <rect x='262.52' y='224.52' width='223.26' height='34.61' />
+  <clipPath id='cpMjYyLjUyfDQ4NS43OHwyMjQuNTJ8MjQxLjgz'>
+    <rect x='262.52' y='224.52' width='223.26' height='17.30' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjYyLjUyfDQ4NS43OHwyMjQuNTJ8MjU5LjEz)'>
+<g clip-path='url(#cpMjYyLjUyfDQ4NS43OHwyMjQuNTJ8MjQxLjgz)'>
 <rect x='262.52' y='224.52' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='374.15' y='237.72' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='38.17px' lengthAdjust='spacingAndGlyphs'>y1_Cp</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjYyLjUyfDQ4NS43OHwyNDEuODN8MjU5LjEz'>
+    <rect x='262.52' y='241.83' width='223.26' height='17.30' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjYyLjUyfDQ4NS43OHwyNDEuODN8MjU5LjEz)'>
 <rect x='262.52' y='241.83' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='374.15' y='255.02' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='7.34px' lengthAdjust='spacingAndGlyphs'>5</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNDkxLjI2fDcxNC41MnwyMjQuNTJ8MjU5LjEz'>
-    <rect x='491.26' y='224.52' width='223.26' height='34.61' />
+  <clipPath id='cpNDkxLjI2fDcxNC41MnwyMjQuNTJ8MjQxLjgz'>
+    <rect x='491.26' y='224.52' width='223.26' height='17.30' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNDkxLjI2fDcxNC41MnwyMjQuNTJ8MjU5LjEz)'>
+<g clip-path='url(#cpNDkxLjI2fDcxNC41MnwyMjQuNTJ8MjQxLjgz)'>
 <rect x='491.26' y='224.52' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='602.89' y='237.72' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='38.17px' lengthAdjust='spacingAndGlyphs'>y1_Cp</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDkxLjI2fDcxNC41MnwyNDEuODN8MjU5LjEz'>
+    <rect x='491.26' y='241.83' width='223.26' height='17.30' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDkxLjI2fDcxNC41MnwyNDEuODN8MjU5LjEz)'>
 <rect x='491.26' y='241.83' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='602.89' y='255.02' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='7.34px' lengthAdjust='spacingAndGlyphs'>6</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMzMuNzh8MjU3LjA0fDYxLjk4fDk2LjU5'>
-    <rect x='33.78' y='61.98' width='223.26' height='34.61' />
+  <clipPath id='cpMzMuNzh8MjU3LjA0fDYxLjk4fDc5LjI5'>
+    <rect x='33.78' y='61.98' width='223.26' height='17.30' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzMuNzh8MjU3LjA0fDYxLjk4fDk2LjU5)'>
+<g clip-path='url(#cpMzMuNzh8MjU3LjA0fDYxLjk4fDc5LjI5)'>
 <rect x='33.78' y='61.98' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='145.41' y='75.18' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='38.17px' lengthAdjust='spacingAndGlyphs'>y1_Cp</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMzMuNzh8MjU3LjA0fDc5LjI5fDk2LjU5'>
+    <rect x='33.78' y='79.29' width='223.26' height='17.30' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzMuNzh8MjU3LjA0fDc5LjI5fDk2LjU5)'>
 <rect x='33.78' y='79.29' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='145.41' y='92.48' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='7.34px' lengthAdjust='spacingAndGlyphs'>1</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMjYyLjUyfDQ4NS43OHw2MS45OHw5Ni41OQ=='>
-    <rect x='262.52' y='61.98' width='223.26' height='34.61' />
+  <clipPath id='cpMjYyLjUyfDQ4NS43OHw2MS45OHw3OS4yOQ=='>
+    <rect x='262.52' y='61.98' width='223.26' height='17.30' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjYyLjUyfDQ4NS43OHw2MS45OHw5Ni41OQ==)'>
+<g clip-path='url(#cpMjYyLjUyfDQ4NS43OHw2MS45OHw3OS4yOQ==)'>
 <rect x='262.52' y='61.98' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='374.15' y='75.18' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='38.17px' lengthAdjust='spacingAndGlyphs'>y1_Cp</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjYyLjUyfDQ4NS43OHw3OS4yOXw5Ni41OQ=='>
+    <rect x='262.52' y='79.29' width='223.26' height='17.30' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjYyLjUyfDQ4NS43OHw3OS4yOXw5Ni41OQ==)'>
 <rect x='262.52' y='79.29' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='374.15' y='92.48' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='7.34px' lengthAdjust='spacingAndGlyphs'>2</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNDkxLjI2fDcxNC41Mnw2MS45OHw5Ni41OQ=='>
-    <rect x='491.26' y='61.98' width='223.26' height='34.61' />
+  <clipPath id='cpNDkxLjI2fDcxNC41Mnw2MS45OHw3OS4yOQ=='>
+    <rect x='491.26' y='61.98' width='223.26' height='17.30' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNDkxLjI2fDcxNC41Mnw2MS45OHw5Ni41OQ==)'>
+<g clip-path='url(#cpNDkxLjI2fDcxNC41Mnw2MS45OHw3OS4yOQ==)'>
 <rect x='491.26' y='61.98' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='602.89' y='75.18' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='38.17px' lengthAdjust='spacingAndGlyphs'>y1_Cp</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDkxLjI2fDcxNC41Mnw3OS4yOXw5Ni41OQ=='>
+    <rect x='491.26' y='79.29' width='223.26' height='17.30' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDkxLjI2fDcxNC41Mnw3OS4yOXw5Ni41OQ==)'>
 <rect x='491.26' y='79.29' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='602.89' y='92.48' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='7.34px' lengthAdjust='spacingAndGlyphs'>3</text>
 </g>

--- a/tests/testthat/_snaps/data-import/multiple-endpoint-theo-pall.svg
+++ b/tests/testthat/_snaps/data-import/multiple-endpoint-theo-pall.svg
@@ -543,117 +543,198 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMzMuNzh8MjU3LjA0fDM4Ny4wNnw0MjEuNjc='>
-    <rect x='33.78' y='387.06' width='223.26' height='34.61' />
+  <clipPath id='cpMzMuNzh8MjU3LjA0fDM4Ny4wNnw0MDQuMzc='>
+    <rect x='33.78' y='387.06' width='223.26' height='17.30' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzMuNzh8MjU3LjA0fDM4Ny4wNnw0MjEuNjc=)'>
+<g clip-path='url(#cpMzMuNzh8MjU3LjA0fDM4Ny4wNnw0MDQuMzc=)'>
 <rect x='33.78' y='387.06' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='145.41' y='400.26' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='38.17px' lengthAdjust='spacingAndGlyphs'>y1_Cp</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMzMuNzh8MjU3LjA0fDQwNC4zN3w0MjEuNjc='>
+    <rect x='33.78' y='404.37' width='223.26' height='17.30' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzMuNzh8MjU3LjA0fDQwNC4zN3w0MjEuNjc=)'>
 <rect x='33.78' y='404.37' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='145.41' y='417.56' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>79</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMjYyLjUyfDQ4NS43OHwzODcuMDZ8NDIxLjY3'>
-    <rect x='262.52' y='387.06' width='223.26' height='34.61' />
+  <clipPath id='cpMjYyLjUyfDQ4NS43OHwzODcuMDZ8NDA0LjM3'>
+    <rect x='262.52' y='387.06' width='223.26' height='17.30' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjYyLjUyfDQ4NS43OHwzODcuMDZ8NDIxLjY3)'>
+<g clip-path='url(#cpMjYyLjUyfDQ4NS43OHwzODcuMDZ8NDA0LjM3)'>
 <rect x='262.52' y='387.06' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='374.15' y='400.26' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='38.17px' lengthAdjust='spacingAndGlyphs'>y1_Cp</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjYyLjUyfDQ4NS43OHw0MDQuMzd8NDIxLjY3'>
+    <rect x='262.52' y='404.37' width='223.26' height='17.30' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjYyLjUyfDQ4NS43OHw0MDQuMzd8NDIxLjY3)'>
 <rect x='262.52' y='404.37' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='374.15' y='417.56' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>80</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNDkxLjI2fDcxNC41MnwzODcuMDZ8NDIxLjY3'>
-    <rect x='491.26' y='387.06' width='223.26' height='34.61' />
+  <clipPath id='cpNDkxLjI2fDcxNC41MnwzODcuMDZ8NDA0LjM3'>
+    <rect x='491.26' y='387.06' width='223.26' height='17.30' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNDkxLjI2fDcxNC41MnwzODcuMDZ8NDIxLjY3)'>
+<g clip-path='url(#cpNDkxLjI2fDcxNC41MnwzODcuMDZ8NDA0LjM3)'>
 <rect x='491.26' y='387.06' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='602.89' y='400.26' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='41.83px' lengthAdjust='spacingAndGlyphs'>y2_Cm</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDkxLjI2fDcxNC41Mnw0MDQuMzd8NDIxLjY3'>
+    <rect x='491.26' y='404.37' width='223.26' height='17.30' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDkxLjI2fDcxNC41Mnw0MDQuMzd8NDIxLjY3)'>
 <rect x='491.26' y='404.37' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='602.89' y='417.56' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='7.34px' lengthAdjust='spacingAndGlyphs'>1</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMzMuNzh8MjU3LjA0fDIyNC41MnwyNTkuMTM='>
-    <rect x='33.78' y='224.52' width='223.26' height='34.61' />
+  <clipPath id='cpMzMuNzh8MjU3LjA0fDIyNC41MnwyNDEuODM='>
+    <rect x='33.78' y='224.52' width='223.26' height='17.30' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzMuNzh8MjU3LjA0fDIyNC41MnwyNTkuMTM=)'>
+<g clip-path='url(#cpMzMuNzh8MjU3LjA0fDIyNC41MnwyNDEuODM=)'>
 <rect x='33.78' y='224.52' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='145.41' y='237.72' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='38.17px' lengthAdjust='spacingAndGlyphs'>y1_Cp</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMzMuNzh8MjU3LjA0fDI0MS44M3wyNTkuMTM='>
+    <rect x='33.78' y='241.83' width='223.26' height='17.30' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzMuNzh8MjU3LjA0fDI0MS44M3wyNTkuMTM=)'>
 <rect x='33.78' y='241.83' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='145.41' y='255.02' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>76</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMjYyLjUyfDQ4NS43OHwyMjQuNTJ8MjU5LjEz'>
-    <rect x='262.52' y='224.52' width='223.26' height='34.61' />
+  <clipPath id='cpMjYyLjUyfDQ4NS43OHwyMjQuNTJ8MjQxLjgz'>
+    <rect x='262.52' y='224.52' width='223.26' height='17.30' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjYyLjUyfDQ4NS43OHwyMjQuNTJ8MjU5LjEz)'>
+<g clip-path='url(#cpMjYyLjUyfDQ4NS43OHwyMjQuNTJ8MjQxLjgz)'>
 <rect x='262.52' y='224.52' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='374.15' y='237.72' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='38.17px' lengthAdjust='spacingAndGlyphs'>y1_Cp</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjYyLjUyfDQ4NS43OHwyNDEuODN8MjU5LjEz'>
+    <rect x='262.52' y='241.83' width='223.26' height='17.30' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjYyLjUyfDQ4NS43OHwyNDEuODN8MjU5LjEz)'>
 <rect x='262.52' y='241.83' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='374.15' y='255.02' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>77</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNDkxLjI2fDcxNC41MnwyMjQuNTJ8MjU5LjEz'>
-    <rect x='491.26' y='224.52' width='223.26' height='34.61' />
+  <clipPath id='cpNDkxLjI2fDcxNC41MnwyMjQuNTJ8MjQxLjgz'>
+    <rect x='491.26' y='224.52' width='223.26' height='17.30' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNDkxLjI2fDcxNC41MnwyMjQuNTJ8MjU5LjEz)'>
+<g clip-path='url(#cpNDkxLjI2fDcxNC41MnwyMjQuNTJ8MjQxLjgz)'>
 <rect x='491.26' y='224.52' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='602.89' y='237.72' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='38.17px' lengthAdjust='spacingAndGlyphs'>y1_Cp</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDkxLjI2fDcxNC41MnwyNDEuODN8MjU5LjEz'>
+    <rect x='491.26' y='241.83' width='223.26' height='17.30' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDkxLjI2fDcxNC41MnwyNDEuODN8MjU5LjEz)'>
 <rect x='491.26' y='241.83' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='602.89' y='255.02' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>78</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMzMuNzh8MjU3LjA0fDYxLjk4fDk2LjU5'>
-    <rect x='33.78' y='61.98' width='223.26' height='34.61' />
+  <clipPath id='cpMzMuNzh8MjU3LjA0fDYxLjk4fDc5LjI5'>
+    <rect x='33.78' y='61.98' width='223.26' height='17.30' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzMuNzh8MjU3LjA0fDYxLjk4fDk2LjU5)'>
+<g clip-path='url(#cpMzMuNzh8MjU3LjA0fDYxLjk4fDc5LjI5)'>
 <rect x='33.78' y='61.98' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='145.41' y='75.18' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='38.17px' lengthAdjust='spacingAndGlyphs'>y1_Cp</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMzMuNzh8MjU3LjA0fDc5LjI5fDk2LjU5'>
+    <rect x='33.78' y='79.29' width='223.26' height='17.30' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzMuNzh8MjU3LjA0fDc5LjI5fDk2LjU5)'>
 <rect x='33.78' y='79.29' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='145.41' y='92.48' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>73</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMjYyLjUyfDQ4NS43OHw2MS45OHw5Ni41OQ=='>
-    <rect x='262.52' y='61.98' width='223.26' height='34.61' />
+  <clipPath id='cpMjYyLjUyfDQ4NS43OHw2MS45OHw3OS4yOQ=='>
+    <rect x='262.52' y='61.98' width='223.26' height='17.30' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjYyLjUyfDQ4NS43OHw2MS45OHw5Ni41OQ==)'>
+<g clip-path='url(#cpMjYyLjUyfDQ4NS43OHw2MS45OHw3OS4yOQ==)'>
 <rect x='262.52' y='61.98' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='374.15' y='75.18' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='38.17px' lengthAdjust='spacingAndGlyphs'>y1_Cp</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjYyLjUyfDQ4NS43OHw3OS4yOXw5Ni41OQ=='>
+    <rect x='262.52' y='79.29' width='223.26' height='17.30' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjYyLjUyfDQ4NS43OHw3OS4yOXw5Ni41OQ==)'>
 <rect x='262.52' y='79.29' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='374.15' y='92.48' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>74</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNDkxLjI2fDcxNC41Mnw2MS45OHw5Ni41OQ=='>
-    <rect x='491.26' y='61.98' width='223.26' height='34.61' />
+  <clipPath id='cpNDkxLjI2fDcxNC41Mnw2MS45OHw3OS4yOQ=='>
+    <rect x='491.26' y='61.98' width='223.26' height='17.30' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNDkxLjI2fDcxNC41Mnw2MS45OHw5Ni41OQ==)'>
+<g clip-path='url(#cpNDkxLjI2fDcxNC41Mnw2MS45OHw3OS4yOQ==)'>
 <rect x='491.26' y='61.98' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='602.89' y='75.18' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='38.17px' lengthAdjust='spacingAndGlyphs'>y1_Cp</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDkxLjI2fDcxNC41Mnw3OS4yOXw5Ni41OQ=='>
+    <rect x='491.26' y='79.29' width='223.26' height='17.30' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDkxLjI2fDcxNC41Mnw3OS4yOXw5Ni41OQ==)'>
 <rect x='491.26' y='79.29' width='223.26' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='602.89' y='92.48' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>75</text>
 </g>

--- a/tests/testthat/_snaps/data-import/multiple-endpoint-theo.svg
+++ b/tests/testthat/_snaps/data-import/multiple-endpoint-theo.svg
@@ -8002,78 +8002,132 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMzMuNzh8MjQ3Ljg4fDI4My45NXwzMTguNTY='>
-    <rect x='33.78' y='283.95' width='214.10' height='34.61' />
+  <clipPath id='cpMzMuNzh8MjQ3Ljg4fDI4My45NXwzMDEuMjU='>
+    <rect x='33.78' y='283.95' width='214.10' height='17.30' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzMuNzh8MjQ3Ljg4fDI4My45NXwzMTguNTY=)'>
+<g clip-path='url(#cpMzMuNzh8MjQ3Ljg4fDI4My45NXwzMDEuMjU=)'>
 <rect x='33.78' y='283.95' width='214.10' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='140.83' y='297.14' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='41.83px' lengthAdjust='spacingAndGlyphs'>y2_Cm</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMzMuNzh8MjQ3Ljg4fDMwMS4yNXwzMTguNTY='>
+    <rect x='33.78' y='301.25' width='214.10' height='17.30' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzMuNzh8MjQ3Ljg4fDMwMS4yNXwzMTguNTY=)'>
 <rect x='33.78' y='301.25' width='214.10' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='140.83' y='314.45' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='29.35px' lengthAdjust='spacingAndGlyphs'>ipred</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMjY2LjEyfDQ4MC4yMnwyODMuOTV8MzE4LjU2'>
-    <rect x='266.12' y='283.95' width='214.10' height='34.61' />
+  <clipPath id='cpMjY2LjEyfDQ4MC4yMnwyODMuOTV8MzAxLjI1'>
+    <rect x='266.12' y='283.95' width='214.10' height='17.30' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjY2LjEyfDQ4MC4yMnwyODMuOTV8MzE4LjU2)'>
+<g clip-path='url(#cpMjY2LjEyfDQ4MC4yMnwyODMuOTV8MzAxLjI1)'>
 <rect x='266.12' y='283.95' width='214.10' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='373.17' y='297.14' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='41.83px' lengthAdjust='spacingAndGlyphs'>y2_Cm</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjY2LjEyfDQ4MC4yMnwzMDEuMjV8MzE4LjU2'>
+    <rect x='266.12' y='301.25' width='214.10' height='17.30' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjY2LjEyfDQ4MC4yMnwzMDEuMjV8MzE4LjU2)'>
 <rect x='266.12' y='301.25' width='214.10' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='373.17' y='314.45' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='30.81px' lengthAdjust='spacingAndGlyphs'>iwres</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNTAwLjQyfDcxNC41MnwyODMuOTV8MzE4LjU2'>
-    <rect x='500.42' y='283.95' width='214.10' height='34.61' />
+  <clipPath id='cpNTAwLjQyfDcxNC41MnwyODMuOTV8MzAxLjI1'>
+    <rect x='500.42' y='283.95' width='214.10' height='17.30' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNTAwLjQyfDcxNC41MnwyODMuOTV8MzE4LjU2)'>
+<g clip-path='url(#cpNTAwLjQyfDcxNC41MnwyODMuOTV8MzAxLjI1)'>
 <rect x='500.42' y='283.95' width='214.10' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='607.47' y='297.14' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='41.83px' lengthAdjust='spacingAndGlyphs'>y2_Cm</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTAwLjQyfDcxNC41MnwzMDEuMjV8MzE4LjU2'>
+    <rect x='500.42' y='301.25' width='214.10' height='17.30' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTAwLjQyfDcxNC41MnwzMDEuMjV8MzE4LjU2)'>
 <rect x='500.42' y='301.25' width='214.10' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='607.47' y='314.45' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='26.42px' lengthAdjust='spacingAndGlyphs'>pred</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMzMuNzh8MjQ3Ljg4fDUuNDh8NDAuMDk='>
-    <rect x='33.78' y='5.48' width='214.10' height='34.61' />
+  <clipPath id='cpMzMuNzh8MjQ3Ljg4fDUuNDh8MjIuNzg='>
+    <rect x='33.78' y='5.48' width='214.10' height='17.30' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzMuNzh8MjQ3Ljg4fDUuNDh8NDAuMDk=)'>
+<g clip-path='url(#cpMzMuNzh8MjQ3Ljg4fDUuNDh8MjIuNzg=)'>
 <rect x='33.78' y='5.48' width='214.10' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='140.83' y='18.67' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='38.17px' lengthAdjust='spacingAndGlyphs'>y1_Cp</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMzMuNzh8MjQ3Ljg4fDIyLjc4fDQwLjA5'>
+    <rect x='33.78' y='22.78' width='214.10' height='17.30' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzMuNzh8MjQ3Ljg4fDIyLjc4fDQwLjA5)'>
 <rect x='33.78' y='22.78' width='214.10' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='140.83' y='35.98' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='29.35px' lengthAdjust='spacingAndGlyphs'>ipred</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMjY2LjEyfDQ4MC4yMnw1LjQ4fDQwLjA5'>
-    <rect x='266.12' y='5.48' width='214.10' height='34.61' />
+  <clipPath id='cpMjY2LjEyfDQ4MC4yMnw1LjQ4fDIyLjc4'>
+    <rect x='266.12' y='5.48' width='214.10' height='17.30' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjY2LjEyfDQ4MC4yMnw1LjQ4fDQwLjA5)'>
+<g clip-path='url(#cpMjY2LjEyfDQ4MC4yMnw1LjQ4fDIyLjc4)'>
 <rect x='266.12' y='5.48' width='214.10' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='373.17' y='18.67' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='38.17px' lengthAdjust='spacingAndGlyphs'>y1_Cp</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjY2LjEyfDQ4MC4yMnwyMi43OHw0MC4wOQ=='>
+    <rect x='266.12' y='22.78' width='214.10' height='17.30' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjY2LjEyfDQ4MC4yMnwyMi43OHw0MC4wOQ==)'>
 <rect x='266.12' y='22.78' width='214.10' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='373.17' y='35.98' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='30.81px' lengthAdjust='spacingAndGlyphs'>iwres</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNTAwLjQyfDcxNC41Mnw1LjQ4fDQwLjA5'>
-    <rect x='500.42' y='5.48' width='214.10' height='34.61' />
+  <clipPath id='cpNTAwLjQyfDcxNC41Mnw1LjQ4fDIyLjc4'>
+    <rect x='500.42' y='5.48' width='214.10' height='17.30' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNTAwLjQyfDcxNC41Mnw1LjQ4fDQwLjA5)'>
+<g clip-path='url(#cpNTAwLjQyfDcxNC41Mnw1LjQ4fDIyLjc4)'>
 <rect x='500.42' y='5.48' width='214.10' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='607.47' y='18.67' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='38.17px' lengthAdjust='spacingAndGlyphs'>y1_Cp</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTAwLjQyfDcxNC41MnwyMi43OHw0MC4wOQ=='>
+    <rect x='500.42' y='22.78' width='214.10' height='17.30' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTAwLjQyfDcxNC41MnwyMi43OHw0MC4wOQ==)'>
 <rect x='500.42' y='22.78' width='214.10' height='17.30' style='stroke-width: 1.07; stroke: none; fill: #808078;' />
 <text x='607.47' y='35.98' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='26.42px' lengthAdjust='spacingAndGlyphs'>pred</text>
 </g>

--- a/tests/testthat/_snaps/data-import/single-endpoint-theo-pall.svg
+++ b/tests/testthat/_snaps/data-import/single-endpoint-theo-pall.svg
@@ -21,152 +21,152 @@
 <rect x='0.000000000000064' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
-  <clipPath id='cpMjguODh8MjUzLjc4fDc5LjI5fDIxOS4wNA=='>
-    <rect x='28.88' y='79.29' width='224.89' height='139.76' />
+  <clipPath id='cpMjguODh8MjUzLjc4fDc5LjI5fDIyMi43MA=='>
+    <rect x='28.88' y='79.29' width='224.89' height='143.41' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjguODh8MjUzLjc4fDc5LjI5fDIxOS4wNA==)'>
-<rect x='28.88' y='79.29' width='224.89' height='139.76' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polyline points='28.88,203.47 253.78,203.47 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
-<polyline points='28.88,165.48 253.78,165.48 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
-<polyline points='28.88,127.49 253.78,127.49 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
-<polyline points='28.88,89.51 253.78,89.51 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
-<polyline points='57.96,219.04 57.96,79.29 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
-<polyline points='99.85,219.04 99.85,79.29 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
-<polyline points='141.75,219.04 141.75,79.29 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
-<polyline points='183.64,219.04 183.64,79.29 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
-<polyline points='225.54,219.04 225.54,79.29 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
-<polyline points='28.88,184.48 253.78,184.48 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
-<polyline points='28.88,146.49 253.78,146.49 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
-<polyline points='28.88,108.50 253.78,108.50 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
-<polyline points='37.01,219.04 37.01,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
-<polyline points='78.91,219.04 78.91,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
-<polyline points='120.80,219.04 120.80,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
-<polyline points='162.70,219.04 162.70,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
-<polyline points='204.59,219.04 204.59,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
-<polyline points='246.49,219.04 246.49,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
-<circle cx='40.11' cy='157.46' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='43.46' cy='120.73' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='45.56' cy='108.17' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='138.40' cy='166.66' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='54.19' cy='94.07' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='235.59' cy='202.41' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='66.76' cy='104.55' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='79.33' cy='118.61' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='96.34' cy='135.58' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='115.61' cy='151.53' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='40.11' cy='185.56' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='43.46' cy='156.71' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='45.56' cy='143.18' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='138.40' cy='150.76' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='54.19' cy='111.66' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='235.59' cy='191.32' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='66.76' cy='101.86' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='79.33' cy='107.31' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='96.34' cy='120.43' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='115.61' cy='135.41' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<polyline points='40.11,185.54 43.46,156.69 45.56,143.15 54.19,111.64 66.76,101.86 79.33,107.35 96.34,120.49 115.61,135.50 138.40,150.87 235.59,191.43 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
-<polyline points='40.11,157.46 43.46,120.73 45.56,108.17 54.19,94.07 66.76,104.55 79.33,118.61 96.34,135.58 115.61,151.53 138.40,166.66 235.59,202.41 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<g clip-path='url(#cpMjguODh8MjUzLjc4fDc5LjI5fDIyMi43MA==)'>
+<rect x='28.88' y='79.29' width='224.89' height='143.41' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='28.88,206.72 253.78,206.72 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
+<polyline points='28.88,167.74 253.78,167.74 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
+<polyline points='28.88,128.76 253.78,128.76 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
+<polyline points='28.88,89.77 253.78,89.77 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
+<polyline points='57.96,222.70 57.96,79.29 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
+<polyline points='99.85,222.70 99.85,79.29 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
+<polyline points='141.75,222.70 141.75,79.29 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
+<polyline points='183.64,222.70 183.64,79.29 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
+<polyline points='225.54,222.70 225.54,79.29 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
+<polyline points='28.88,187.23 253.78,187.23 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
+<polyline points='28.88,148.25 253.78,148.25 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
+<polyline points='28.88,109.26 253.78,109.26 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
+<polyline points='37.01,222.70 37.01,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
+<polyline points='78.91,222.70 78.91,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
+<polyline points='120.80,222.70 120.80,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
+<polyline points='162.70,222.70 162.70,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
+<polyline points='204.59,222.70 204.59,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
+<polyline points='246.49,222.70 246.49,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
+<circle cx='40.11' cy='159.50' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='43.46' cy='121.81' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='45.56' cy='108.92' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='138.40' cy='168.94' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='54.19' cy='94.46' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='235.59' cy='205.62' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='66.76' cy='105.21' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='79.33' cy='119.64' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='96.34' cy='137.05' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='115.61' cy='153.42' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='40.11' cy='188.34' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='43.46' cy='158.73' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='45.56' cy='144.85' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='138.40' cy='152.63' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='54.19' cy='112.50' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='235.59' cy='194.25' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='66.76' cy='102.45' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='79.33' cy='108.05' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='96.34' cy='121.50' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='115.61' cy='136.87' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<polyline points='40.11,188.32 43.46,158.71 45.56,144.82 54.19,112.48 66.76,102.45 79.33,108.08 96.34,121.57 115.61,136.96 138.40,152.74 235.59,194.36 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='40.11,159.50 43.46,121.81 45.56,108.92 54.19,94.46 66.76,105.21 79.33,119.64 96.34,137.05 115.61,153.42 138.40,168.94 235.59,205.62 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMjU5LjI2fDQ4NC4xNXw3OS4yOXwyMTkuMDQ='>
-    <rect x='259.26' y='79.29' width='224.89' height='139.76' />
+  <clipPath id='cpMjU5LjI2fDQ4NC4xNXw3OS4yOXwyMjIuNzA='>
+    <rect x='259.26' y='79.29' width='224.89' height='143.41' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMjU5LjI2fDQ4NC4xNXw3OS4yOXwyMTkuMDQ=)'>
-<rect x='259.26' y='79.29' width='224.89' height='139.76' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polyline points='259.26,203.47 484.15,203.47 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
-<polyline points='259.26,165.48 484.15,165.48 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
-<polyline points='259.26,127.49 484.15,127.49 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
-<polyline points='259.26,89.51 484.15,89.51 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
-<polyline points='288.33,219.04 288.33,79.29 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
-<polyline points='330.23,219.04 330.23,79.29 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
-<polyline points='372.12,219.04 372.12,79.29 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
-<polyline points='414.02,219.04 414.02,79.29 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
-<polyline points='455.91,219.04 455.91,79.29 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
-<polyline points='259.26,184.48 484.15,184.48 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
-<polyline points='259.26,146.49 484.15,146.49 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
-<polyline points='259.26,108.50 484.15,108.50 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
-<polyline points='267.38,219.04 267.38,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
-<polyline points='309.28,219.04 309.28,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
-<polyline points='351.17,219.04 351.17,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
-<polyline points='393.07,219.04 393.07,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
-<polyline points='434.96,219.04 434.96,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
-<polyline points='476.86,219.04 476.86,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
-<circle cx='269.48' cy='179.44' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='271.57' cy='151.04' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='275.60' cy='121.67' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='283.97' cy='107.57' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='368.94' cy='172.63' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='469.15' cy='205.11' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='297.55' cy='117.40' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='309.45' cy='129.32' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='326.29' cy='144.40' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='343.05' cy='157.02' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='269.48' cy='160.39' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='271.57' cy='134.27' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='275.60' cy='121.23' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='283.97' cy='126.85' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='368.94' cy='188.76' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='469.15' cy='212.64' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='297.55' cy='141.39' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='309.45' cy='152.42' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='326.29' cy='165.52' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='343.05' cy='176.12' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<polyline points='269.48,160.37 271.57,134.24 275.60,121.21 283.97,126.86 297.55,141.42 309.45,152.48 326.29,165.60 343.05,176.21 368.94,188.85 469.15,212.69 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
-<polyline points='269.48,179.44 271.57,151.04 275.60,121.67 283.97,107.57 297.55,117.40 309.45,129.32 326.29,144.40 343.05,157.02 368.94,172.63 469.15,205.11 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<g clip-path='url(#cpMjU5LjI2fDQ4NC4xNXw3OS4yOXwyMjIuNzA=)'>
+<rect x='259.26' y='79.29' width='224.89' height='143.41' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='259.26,206.72 484.15,206.72 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
+<polyline points='259.26,167.74 484.15,167.74 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
+<polyline points='259.26,128.76 484.15,128.76 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
+<polyline points='259.26,89.77 484.15,89.77 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
+<polyline points='288.33,222.70 288.33,79.29 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
+<polyline points='330.23,222.70 330.23,79.29 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
+<polyline points='372.12,222.70 372.12,79.29 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
+<polyline points='414.02,222.70 414.02,79.29 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
+<polyline points='455.91,222.70 455.91,79.29 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
+<polyline points='259.26,187.23 484.15,187.23 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
+<polyline points='259.26,148.25 484.15,148.25 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
+<polyline points='259.26,109.26 484.15,109.26 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
+<polyline points='267.38,222.70 267.38,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
+<polyline points='309.28,222.70 309.28,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
+<polyline points='351.17,222.70 351.17,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
+<polyline points='393.07,222.70 393.07,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
+<polyline points='434.96,222.70 434.96,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
+<polyline points='476.86,222.70 476.86,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
+<circle cx='269.48' cy='182.06' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='271.57' cy='152.92' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='275.60' cy='122.78' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='283.97' cy='108.31' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='368.94' cy='175.07' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='469.15' cy='208.40' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='297.55' cy='118.40' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='309.45' cy='130.63' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='326.29' cy='146.10' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='343.05' cy='159.05' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='269.48' cy='162.51' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='271.57' cy='135.71' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='275.60' cy='122.33' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='283.97' cy='128.10' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='368.94' cy='191.62' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='469.15' cy='216.12' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='297.55' cy='143.01' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='309.45' cy='154.33' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='326.29' cy='167.77' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='343.05' cy='178.65' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<polyline points='269.48,162.49 271.57,135.68 275.60,122.31 283.97,128.10 297.55,143.05 309.45,154.39 326.29,167.85 343.05,178.74 368.94,191.71 469.15,216.18 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='269.48,182.06 271.57,152.92 275.60,122.78 283.97,108.31 297.55,118.40 309.45,130.63 326.29,146.10 343.05,159.05 368.94,175.07 469.15,208.40 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpNDg5LjYzfDcxNC41Mnw3OS4yOXwyMTkuMDQ='>
-    <rect x='489.63' y='79.29' width='224.89' height='139.76' />
+  <clipPath id='cpNDg5LjYzfDcxNC41Mnw3OS4yOXwyMjIuNzA='>
+    <rect x='489.63' y='79.29' width='224.89' height='143.41' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNDg5LjYzfDcxNC41Mnw3OS4yOXwyMTkuMDQ=)'>
-<rect x='489.63' y='79.29' width='224.89' height='139.76' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polyline points='489.63,203.47 714.52,203.47 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
-<polyline points='489.63,165.48 714.52,165.48 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
-<polyline points='489.63,127.49 714.52,127.49 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
-<polyline points='489.63,89.51 714.52,89.51 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
-<polyline points='518.70,219.04 518.70,79.29 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
-<polyline points='560.60,219.04 560.60,79.29 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
-<polyline points='602.49,219.04 602.49,79.29 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
-<polyline points='644.39,219.04 644.39,79.29 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
-<polyline points='686.28,219.04 686.28,79.29 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
-<polyline points='489.63,184.48 714.52,184.48 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
-<polyline points='489.63,146.49 714.52,146.49 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
-<polyline points='489.63,108.50 714.52,108.50 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
-<polyline points='497.76,219.04 497.76,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
-<polyline points='539.65,219.04 539.65,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
-<polyline points='581.55,219.04 581.55,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
-<polyline points='623.44,219.04 623.44,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
-<polyline points='665.34,219.04 665.34,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
-<polyline points='707.23,219.04 707.23,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
-<circle cx='499.85' cy='176.12' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='501.95' cy='145.53' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='506.13' cy='113.09' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='598.72' cy='168.45' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='514.51' cy='98.70' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='700.11' cy='203.89' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='527.25' cy='108.56' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='540.24' cy='122.56' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='557.00' cy='138.67' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='573.42' cy='151.97' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
-<circle cx='499.85' cy='191.52' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='501.95' cy='167.43' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='506.13' cy='134.64' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='598.72' cy='166.42' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='514.51' cy='106.38' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='700.11' cy='204.80' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='527.25' cy='103.83' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='540.24' cy='115.36' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='557.00' cy='132.66' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<circle cx='573.42' cy='147.75' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
-<polyline points='499.85,191.50 501.95,167.42 506.13,134.62 514.51,106.37 527.25,103.85 540.24,115.41 557.00,132.75 573.42,147.86 598.72,166.54 700.11,204.88 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
-<polyline points='499.85,176.12 501.95,145.53 506.13,113.09 514.51,98.70 527.25,108.56 540.24,122.56 557.00,138.67 573.42,151.97 598.72,168.45 700.11,203.89 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
+<g clip-path='url(#cpNDg5LjYzfDcxNC41Mnw3OS4yOXwyMjIuNzA=)'>
+<rect x='489.63' y='79.29' width='224.89' height='143.41' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='489.63,206.72 714.52,206.72 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
+<polyline points='489.63,167.74 714.52,167.74 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
+<polyline points='489.63,128.76 714.52,128.76 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
+<polyline points='489.63,89.77 714.52,89.77 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
+<polyline points='518.70,222.70 518.70,79.29 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
+<polyline points='560.60,222.70 560.60,79.29 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
+<polyline points='602.49,222.70 602.49,79.29 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
+<polyline points='644.39,222.70 644.39,79.29 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
+<polyline points='686.28,222.70 686.28,79.29 ' style='stroke-width: 1.07; stroke: #E6E6D8; stroke-linecap: butt;' />
+<polyline points='489.63,187.23 714.52,187.23 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
+<polyline points='489.63,148.25 714.52,148.25 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
+<polyline points='489.63,109.26 714.52,109.26 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
+<polyline points='497.76,222.70 497.76,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
+<polyline points='539.65,222.70 539.65,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
+<polyline points='581.55,222.70 581.55,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
+<polyline points='623.44,222.70 623.44,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
+<polyline points='665.34,222.70 665.34,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
+<polyline points='707.23,222.70 707.23,79.29 ' style='stroke-width: 1.07; stroke: #BFBFB4; stroke-linecap: butt;' />
+<circle cx='499.85' cy='178.65' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='501.95' cy='147.26' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='506.13' cy='113.98' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='598.72' cy='170.78' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='514.51' cy='99.21' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='700.11' cy='207.14' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='527.25' cy='109.33' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='540.24' cy='123.69' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='557.00' cy='140.22' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='573.42' cy='153.87' r='1.95' style='stroke-width: 0.71; stroke: #00BFC4; fill: #00BFC4;' />
+<circle cx='499.85' cy='194.45' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='501.95' cy='169.74' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='506.13' cy='136.09' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='598.72' cy='168.69' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='514.51' cy='107.09' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='700.11' cy='208.08' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='527.25' cy='104.47' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='540.24' cy='116.30' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='557.00' cy='134.05' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<circle cx='573.42' cy='149.54' r='1.95' style='stroke-width: 0.71; stroke: #F8766D; fill: #F8766D;' />
+<polyline points='499.85,194.44 501.95,169.72 506.13,136.06 514.51,107.08 527.25,104.50 540.24,116.36 557.00,134.14 573.42,149.65 598.72,168.82 700.11,208.17 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='499.85,178.65 501.95,147.26 506.13,113.97 514.51,99.21 527.25,109.33 540.24,123.69 557.00,140.22 573.42,153.87 598.72,170.78 700.11,207.14 ' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -202,50 +202,50 @@
 <text x='602.07' y='75.18' text-anchor='middle' style='font-size: 13.20px; font-weight: bold; fill: #FFFFF7; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>12</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='37.01,221.78 37.01,219.04 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
-<polyline points='78.91,221.78 78.91,219.04 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
-<polyline points='120.80,221.78 120.80,219.04 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
-<polyline points='162.70,221.78 162.70,219.04 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
-<polyline points='204.59,221.78 204.59,219.04 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
-<polyline points='246.49,221.78 246.49,219.04 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
-<text x='37.01' y='230.03' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='78.91' y='230.03' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
-<text x='120.80' y='230.03' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
-<text x='162.70' y='230.03' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
-<text x='204.59' y='230.03' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
-<text x='246.49' y='230.03' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
-<polyline points='267.38,221.78 267.38,219.04 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
-<polyline points='309.28,221.78 309.28,219.04 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
-<polyline points='351.17,221.78 351.17,219.04 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
-<polyline points='393.07,221.78 393.07,219.04 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
-<polyline points='434.96,221.78 434.96,219.04 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
-<polyline points='476.86,221.78 476.86,219.04 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
-<text x='267.38' y='230.03' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='309.28' y='230.03' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
-<text x='351.17' y='230.03' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
-<text x='393.07' y='230.03' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
-<text x='434.96' y='230.03' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
-<text x='476.86' y='230.03' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
-<polyline points='497.76,221.78 497.76,219.04 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
-<polyline points='539.65,221.78 539.65,219.04 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
-<polyline points='581.55,221.78 581.55,219.04 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
-<polyline points='623.44,221.78 623.44,219.04 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
-<polyline points='665.34,221.78 665.34,219.04 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
-<polyline points='707.23,221.78 707.23,219.04 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
-<text x='497.76' y='230.03' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='539.65' y='230.03' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
-<text x='581.55' y='230.03' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
-<text x='623.44' y='230.03' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
-<text x='665.34' y='230.03' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
-<text x='707.23' y='230.03' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
-<text x='23.95' y='187.51' text-anchor='end' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
-<text x='23.95' y='149.52' text-anchor='end' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
-<text x='23.95' y='111.53' text-anchor='end' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>9</text>
-<polyline points='26.14,184.48 28.88,184.48 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
-<polyline points='26.14,146.49 28.88,146.49 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
-<polyline points='26.14,108.50 28.88,108.50 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
+<polyline points='37.01,225.44 37.01,222.70 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
+<polyline points='78.91,225.44 78.91,222.70 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
+<polyline points='120.80,225.44 120.80,222.70 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
+<polyline points='162.70,225.44 162.70,222.70 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
+<polyline points='204.59,225.44 204.59,222.70 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
+<polyline points='246.49,225.44 246.49,222.70 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
+<text x='37.01' y='233.68' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='78.91' y='233.68' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='120.80' y='233.68' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='162.70' y='233.68' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='204.59' y='233.68' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='246.49' y='233.68' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
+<polyline points='267.38,225.44 267.38,222.70 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
+<polyline points='309.28,225.44 309.28,222.70 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
+<polyline points='351.17,225.44 351.17,222.70 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
+<polyline points='393.07,225.44 393.07,222.70 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
+<polyline points='434.96,225.44 434.96,222.70 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
+<polyline points='476.86,225.44 476.86,222.70 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
+<text x='267.38' y='233.68' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='309.28' y='233.68' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='351.17' y='233.68' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='393.07' y='233.68' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='434.96' y='233.68' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='476.86' y='233.68' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
+<polyline points='497.76,225.44 497.76,222.70 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
+<polyline points='539.65,225.44 539.65,222.70 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
+<polyline points='581.55,225.44 581.55,222.70 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
+<polyline points='623.44,225.44 623.44,222.70 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
+<polyline points='665.34,225.44 665.34,222.70 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
+<polyline points='707.23,225.44 707.23,222.70 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
+<text x='497.76' y='233.68' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='539.65' y='233.68' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='581.55' y='233.68' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='623.44' y='233.68' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>15</text>
+<text x='665.34' y='233.68' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='707.23' y='233.68' text-anchor='middle' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text x='23.95' y='190.26' text-anchor='end' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='23.95' y='151.27' text-anchor='end' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='23.95' y='112.29' text-anchor='end' style='font-size: 8.80px; fill: #808078; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>9</text>
+<polyline points='26.14,187.23 28.88,187.23 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
+<polyline points='26.14,148.25 28.88,148.25 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
+<polyline points='26.14,109.26 28.88,109.26 ' style='stroke-width: 1.07; stroke: #808078; stroke-linecap: butt;' />
 <text x='371.70' y='569.26' text-anchor='middle' style='font-size: 12.10px; font-weight: bold; fill: #808078; font-family: sans;' textLength='26.89px' lengthAdjust='spacingAndGlyphs'>Time</text>
-<text transform='translate(15.06,149.16) rotate(-90)' text-anchor='middle' style='font-size: 12.10px; font-weight: bold; fill: #808078; font-family: sans;' textLength='59.87px' lengthAdjust='spacingAndGlyphs'>Predictions</text>
+<text transform='translate(15.06,150.99) rotate(-90)' text-anchor='middle' style='font-size: 12.10px; font-weight: bold; fill: #808078; font-family: sans;' textLength='59.87px' lengthAdjust='spacingAndGlyphs'>Predictions</text>
 <rect x='308.99' y='22.78' width='125.42' height='28.24' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <text x='314.47' y='40.69' style='font-size: 11.00px; font-family: sans;' textLength='20.80px' lengthAdjust='spacingAndGlyphs'>type</text>
 <rect x='340.75' y='28.26' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />


### PR DESCRIPTION
R 4.6.0 (April 2026) and ggplot2 4.0 produce slightly different SVG output than the snapshots recorded under R 4.4/4.5.  Regenerated the four affected snapshots locally under R 4.6.0 + ggplot2 4.0.3 so CI passes again:

  tests/testthat/_snaps/data-import/multiple-endpoint-theo.svg
  tests/testthat/_snaps/data-import/multiple-endpoint-theo-p1.svg
  tests/testthat/_snaps/data-import/multiple-endpoint-theo-pall.svg
  tests/testthat/_snaps/data-import/single-endpoint-theo-pall.svg

No logic changes; snapshots only.