### PR TITLE
Remove duplicate .longDefSetTransformB definition

### DIFF
--- a/R/longDef.R
+++ b/R/longDef.R
@@ -356,9 +356,6 @@
   .monolix2rx$transformCatB <- c(.monolix2rx$transformCatB, as.logical(q))
 }
 
-.longDefSetTransformB <- function(q) {
-  .monolix2rx$transformCatB <- c(.monolix2rx$transformCatB, as.logical(q))
-}
 .longDefSetTransformRef <- function(var, q) {
   .monolix2rx$transformReference <- var
   .monolix2rx$transformReferenceQ <- as.logical(q)


### PR DESCRIPTION
.longDefSetTransformB was defined twice, back-to-back and byte-identical, in R/longDef.R. The second silently masked the first; removed the duplicate.