### PR TITLE
Add integer-overflow guards to sbuf string buffer (sync with rxode2)

### DIFF
--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -1,6 +1,7 @@
 #define USE_FC_LEN_T
 #define STRICT_R_HEADERS
 #include <rxode2parseSbuf.h>
+#include <limits.h>
 #define _(String) (String)
 
 void sIniTo(sbuf *sbb, int to) {
@@ -28,6 +29,9 @@ void sFreeIni(sbuf *sbb) {
 void sAppendN(sbuf *sbb, const char *what, int n) {
   if (sbb->sN == 0) sIni(sbb);
   if (sbb->sN <= 2 + n + sbb->o){
+    if (n > INT_MAX - sbb->o - 2 - SBUF_MXBUF) {
+      (Rf_error)("string buffer size overflow: input too large");
+    }
     int mx = sbb->o + 2 + n + SBUF_MXBUF;
     sbb->s = R_Realloc(sbb->s, mx, char);
     sbb->sN = mx;
@@ -52,6 +56,9 @@ void sAppend(sbuf *sbb, const char *format, ...) {
 #endif
   va_end(copy);
   if (sbb->sN <= sbb->o + n + 1) {
+    if (n > INT_MAX - sbb->o - 1 - SBUF_MXBUF) {
+      (Rf_error)("string buffer size overflow: input too large");
+    }
     int mx = sbb->o + n + 1 + SBUF_MXBUF;
     sbb->s = R_Realloc(sbb->s, mx, char);
     sbb->sN = mx;
@@ -110,6 +117,9 @@ void addLine(vLines *sbb, const char *format, ...) {
   }
   va_end(copy);
   if (sbb->sN <= sbb->o + n){
+    if (n > INT_MAX - sbb->sN - 2 - SBUF_MXBUF) {
+      (Rf_error)("string buffer size overflow: input too large");
+    }
     int mx = sbb->sN + n + 2 + SBUF_MXBUF;
     sbb->s = R_Realloc(sbb->s, mx, char);
     // The sbb->line are not correct any longer because the pointer for sbb->s has been updated;
@@ -122,6 +132,9 @@ void addLine(vLines *sbb, const char *format, ...) {
   vsnprintf(sbb->s + sbb->o, sbb->sN - sbb->o, format, argptr);
   va_end(argptr);
   if (sbb->n + 2 >= sbb->nL){
+    if (n > INT_MAX - sbb->nL - 2 - SBUF_MXLINE) {
+      (Rf_error)("string buffer size overflow: input too large");
+    }
     int mx = sbb->nL + n + 2 + SBUF_MXLINE;
     sbb->lProp = R_Realloc(sbb->lProp, mx, int);
     sbb->lType = R_Realloc(sbb->lType, mx, int);

--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -31,7 +31,10 @@ void sAppendN(sbuf *sbb, const char *what, int n) {
   // The guard has to run before the resize test below: `2 + n + sbb->o` itself
   // overflows for large `n` and wraps negative, which makes the test false and
   // would skip both the reallocation and the guard.
-  if (n < 0 || n > INT_MAX - sbb->o - 2 - SBUF_MXBUF) {
+  if (n < 0) {
+    (Rf_error)("negative length passed to 'sAppendN'");
+  }
+  if (n > INT_MAX - sbb->o - 2 - SBUF_MXBUF) {
     (Rf_error)("string buffer size overflow: input too large");
   }
   if (sbb->sN <= 2 + n + sbb->o){
@@ -51,6 +54,7 @@ void sAppend(sbuf *sbb, const char *format, ...) {
   va_list argptr, copy;
   va_start(argptr, format);
   va_copy(copy, argptr);
+  errno = 0;
 #if defined(_WIN32) || defined(WIN32)
   n = vsnprintf(NULL, 0, format, copy) + 1;
 #else
@@ -60,8 +64,14 @@ void sAppend(sbuf *sbb, const char *format, ...) {
   va_end(copy);
   // Guard before the resize test: `sbb->o + n + 1` overflows for large `n`.
   // `n` is the vsnprintf() length plus one, so it is <= 0 only when vsnprintf()
-  // failed or its own return value overflowed.
-  if (n <= 0 || n > INT_MAX - sbb->o - 1 - SBUF_MXBUF) {
+  // failed (-1) or its own return value overflowed; `addLine` reports the same
+  // condition separately, so keep the two diagnostics distinguishable here too.
+  if (n <= 0) {
+    va_end(argptr);
+    Rf_errorcall(R_NilValue, _("encoding error in 'sAppend' format: '%s' n: %d; errno: %d"),
+                 format, n, errno);
+  }
+  if (n > INT_MAX - sbb->o - 1 - SBUF_MXBUF) {
     va_end(argptr);
     (Rf_error)("string buffer size overflow: input too large");
   }

--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -28,10 +28,13 @@ void sFreeIni(sbuf *sbb) {
 
 void sAppendN(sbuf *sbb, const char *what, int n) {
   if (sbb->sN == 0) sIni(sbb);
+  // The guard has to run before the resize test below: `2 + n + sbb->o` itself
+  // overflows for large `n` and wraps negative, which makes the test false and
+  // would skip both the reallocation and the guard.
+  if (n < 0 || n > INT_MAX - sbb->o - 2 - SBUF_MXBUF) {
+    (Rf_error)("string buffer size overflow: input too large");
+  }
   if (sbb->sN <= 2 + n + sbb->o){
-    if (n > INT_MAX - sbb->o - 2 - SBUF_MXBUF) {
-      (Rf_error)("string buffer size overflow: input too large");
-    }
     int mx = sbb->o + 2 + n + SBUF_MXBUF;
     sbb->s = R_Realloc(sbb->s, mx, char);
     sbb->sN = mx;
@@ -55,10 +58,14 @@ void sAppend(sbuf *sbb, const char *format, ...) {
   n = vsnprintf(zero, 0, format, copy) + 1;
 #endif
   va_end(copy);
+  // Guard before the resize test: `sbb->o + n + 1` overflows for large `n`.
+  // `n` is the vsnprintf() length plus one, so it is <= 0 only when vsnprintf()
+  // failed or its own return value overflowed.
+  if (n <= 0 || n > INT_MAX - sbb->o - 1 - SBUF_MXBUF) {
+    va_end(argptr);
+    (Rf_error)("string buffer size overflow: input too large");
+  }
   if (sbb->sN <= sbb->o + n + 1) {
-    if (n > INT_MAX - sbb->o - 1 - SBUF_MXBUF) {
-      (Rf_error)("string buffer size overflow: input too large");
-    }
     int mx = sbb->o + n + 1 + SBUF_MXBUF;
     sbb->s = R_Realloc(sbb->s, mx, char);
     sbb->sN = mx;
@@ -116,10 +123,14 @@ void addLine(vLines *sbb, const char *format, ...) {
     Rf_errorcall(R_NilValue, _("encoding error in 'addLine' format: '%s' n: %d; errno: %d"), format, n, errno);
   }
   va_end(copy);
+  // Guard before the resize test: `sbb->o + n` overflows for large `n`.  Since
+  // `sbb->o <= sbb->sN`, bounding `n` against `sbb->sN` also keeps `sbb->o + n`
+  // and the `sbb->o += n + 1` below in range.
+  if (n > INT_MAX - sbb->sN - 2 - SBUF_MXBUF) {
+    va_end(argptr);
+    (Rf_error)("string buffer size overflow: input too large");
+  }
   if (sbb->sN <= sbb->o + n){
-    if (n > INT_MAX - sbb->sN - 2 - SBUF_MXBUF) {
-      (Rf_error)("string buffer size overflow: input too large");
-    }
     int mx = sbb->sN + n + 2 + SBUF_MXBUF;
     sbb->s = R_Realloc(sbb->s, mx, char);
     // The sbb->line are not correct any longer because the pointer for sbb->s has been updated;
@@ -133,7 +144,7 @@ void addLine(vLines *sbb, const char *format, ...) {
   va_end(argptr);
   if (sbb->n + 2 >= sbb->nL){
     if (n > INT_MAX - sbb->nL - 2 - SBUF_MXLINE) {
-      (Rf_error)("string buffer size overflow: input too large");
+      (Rf_error)("line array size overflow: too many lines");
     }
     int mx = sbb->nL + n + 2 + SBUF_MXLINE;
     sbb->lProp = R_Realloc(sbb->lProp, mx, int);

--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -50,31 +50,32 @@ void sAppendN(sbuf *sbb, const char *what, int n) {
 void sAppend(sbuf *sbb, const char *format, ...) {
   if (sbb->sN == 0) sIni(sbb);
   if (format == NULL) return;
-  int n = 0;
+  int n = 0, nRaw = 0;
   va_list argptr, copy;
   va_start(argptr, format);
   va_copy(copy, argptr);
   errno = 0;
+  // Keep the raw vsnprintf() length: the `+ 1` below is itself an int overflow
+  // when vsnprintf() reports INT_MAX, so it has to happen after the guards.
 #if defined(_WIN32) || defined(WIN32)
-  n = vsnprintf(NULL, 0, format, copy) + 1;
+  nRaw = vsnprintf(NULL, 0, format, copy);
 #else
   char zero[2];
-  n = vsnprintf(zero, 0, format, copy) + 1;
+  nRaw = vsnprintf(zero, 0, format, copy);
 #endif
   va_end(copy);
-  // Guard before the resize test: `sbb->o + n + 1` overflows for large `n`.
-  // `n` is the vsnprintf() length plus one, so it is <= 0 only when vsnprintf()
-  // failed (-1) or its own return value overflowed; `addLine` reports the same
-  // condition separately, so keep the two diagnostics distinguishable here too.
-  if (n <= 0) {
+  if (nRaw < 0) {
     va_end(argptr);
     Rf_errorcall(R_NilValue, _("encoding error in 'sAppend' format: '%s' n: %d; errno: %d"),
-                 format, n, errno);
+                 format, nRaw, errno);
   }
-  if (n > INT_MAX - sbb->o - 1 - SBUF_MXBUF) {
+  // Bound `nRaw` so that `n = nRaw + 1`, the resize test `sbb->o + n + 1`, the
+  // `mx` below and the trailing `sbb->o += n - 1` all stay within int.
+  if (nRaw > INT_MAX - sbb->o - 2 - SBUF_MXBUF) {
     va_end(argptr);
     (Rf_error)("string buffer size overflow: input too large");
   }
+  n = nRaw + 1;
   if (sbb->sN <= sbb->o + n + 1) {
     int mx = sbb->o + n + 1 + SBUF_MXBUF;
     sbb->s = R_Realloc(sbb->s, mx, char);

--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -28,12 +28,12 @@ void sFreeIni(sbuf *sbb) {
 
 void sAppendN(sbuf *sbb, const char *what, int n) {
   if (sbb->sN == 0) sIni(sbb);
-  // The guard has to run before the resize test below: `2 + n + sbb->o` itself
-  // overflows for large `n` and wraps negative, which makes the test false and
-  // would skip both the reallocation and the guard.
   if (n < 0) {
     (Rf_error)("negative length passed to 'sAppendN'");
   }
+  // The guard has to run before the resize test below: `2 + n + sbb->o` itself
+  // overflows for large `n` and wraps negative, which makes the test false and
+  // would skip both the reallocation and the guard.
   if (n > INT_MAX - sbb->o - 2 - SBUF_MXBUF) {
     (Rf_error)("string buffer size overflow: input too large");
   }
@@ -130,6 +130,8 @@ void addLine(vLines *sbb, const char *format, ...) {
   n = vsnprintf(zero, 0, format, copy);
 #endif
   if (n < 0){
+    va_end(copy);
+    va_end(argptr);
     Rf_errorcall(R_NilValue, _("encoding error in 'addLine' format: '%s' n: %d; errno: %d"), format, n, errno);
   }
   va_end(copy);


### PR DESCRIPTION
monolix2rx vendors the rxode2 sbuf string-buffer implementation but was missing the INT_MAX overflow guards rxode2 added before each R_Realloc in sAppendN/sAppend/addLine. On a pathological (huge) model string the size arithmetic could overflow int and request an undersized/negative allocation. Port the 4 guards (rxode2/src/sbuf.c) so a too-large input errors cleanly.

(The structural fix is to de-vendor sbuf into the shared rxode2parseSbuf.h header; tracked in the cross-package-collision issue.)