### PR TITLE
rxSolve.monolix2rx: use first ODE method as default (length-1)

### DIFF
--- a/R/buildParser.R
+++ b/R/buildParser.R
@@ -110,6 +110,12 @@
 .monolix2rxBuildRxSolve <- function() {
   message("build options for rxSolve to match Monolix")
   .args <- deparse1(eval(str2lang(paste0("args(rxode2::rxSolve)"))))
+  # Keep only the first (preferred) ODE method as the default. rxode2's full
+  # multi-element `method` default is frozen here at build time and goes stale;
+  # a stale multi-element default that no longer matches rxode2's own default
+  # trips odeMethodToInt()'s match.arg() ("'arg' must be of length 1") when the
+  # solve is dispatched. The first element is the default rxode2 would pick.
+  .args <- sub('method = c\\(("[^"]*")[^)]*\\)', "method = \\1", .args)
   .first <- c(strsplit(.args, "[.][.][.]"))[[1]][1]
   .first <- paste(.first,
                   "..., ",

--- a/R/rxSolve.R
+++ b/R/rxSolve.R
@@ -1,8 +1,7 @@
 # This is built from buildParser.R, edit there
 #'@export
 rxSolve.monolix2rx <- function(object, params = NULL, events = NULL, 
-    inits = NULL, scale = NULL, method = c("liblsoda", "lsoda", 
-        "dop853", "indLin"), sigdig = NULL, atol = 1e-08, rtol = 1e-06, 
+    inits = NULL, scale = NULL, method = "liblsoda", sigdig = NULL, atol = 1e-08, rtol = 1e-06,
     maxsteps = 70000L, hmin = 0, hmax = NA_real_, hmaxSd = 0, 
     hini = 0, maxordn = 12L, maxords = 5L, ..., cores, covsInterpolation = c("locf", 
         "linear", "nocb", "midpoint"), nStud = 1L, dfSub = 0, 


### PR DESCRIPTION
## Problem
`rxSolve.monolix2rx` is generated by `buildParser.R`, which snapshots
`args(rxode2::rxSolve)` at build time — freezing rxode2's old multi-element
`method` default `c("liblsoda","lsoda","dop853","indLin")`. rxode2 has since grown
its method list, so the stale multi-element default no longer matches rxode2's own
and trips `odeMethodToInt()`'s `match.arg()` ("'arg' must be of length 1") whenever
a monolix2rx object is solved (test-rxsolve.R).

## Fix
Capture only the first (preferred) method in `buildParser.R`, so the generated
default is length-1 (`"liblsoda"`, the method rxode2 picks anyway):

    .args <- sub('method = c\\(("[^"]*")[^)]*\\)', "method = \\1", .args)

Regenerated `R/rxSolve.R` updated to match. Verified `test-rxsolve` passes (0
failures) even against an unmodified rxode2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)