### PR TITLE
Add `dirn` so Monolix projects outside the working directory translate (#44)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,6 +28,7 @@ License: MIT + file LICENSE
 URL: https://nlmixr2.github.io/monolix2rx/, https://github.com/nlmixr2/monolix2rx/
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.3.2
 LinkingTo:
     dparser,
     rxode2,
@@ -52,4 +53,3 @@ Suggests:
     vdiffr
 Config/testthat/edition: 3
 Config/Needs/website: rmarkdown
-Config/roxygen2/version: 8.1.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,6 @@ License: MIT + file LICENSE
 URL: https://nlmixr2.github.io/monolix2rx/, https://github.com/nlmixr2/monolix2rx/
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
 LinkingTo:
     dparser,
     rxode2,
@@ -53,3 +52,4 @@ Suggests:
     vdiffr
 Config/testthat/edition: 3
 Config/Needs/website: rmarkdown
+Config/roxygen2/version: 8.1.0

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -52,6 +52,8 @@ S3method(print,monolix2rxParameter)
 S3method(print,monolix2rxPk)
 S3method(print,monolix2rxPopDef)
 S3method(print,monolix2rxTask)
+S3method(rxSolve,monolix2rx)
+S3method(rxUiGet,monolixModelIwres)
 export("%>%")
 export("model<-")
 export(.getNbdoses)
@@ -69,9 +71,7 @@ export(model)
 export(monolix2rx)
 export(rxRename)
 export(rxSolve)
-export(rxSolve.monolix2rx)
 export(rxUiGet)
-export(rxUiGet.monolixModelIwres)
 export(rxode)
 export(rxode2)
 import(ggplot2)
@@ -80,22 +80,18 @@ importFrom(dparser,dparse)
 importFrom(ggplot2,autoplot)
 importFrom(lotri,lotri)
 importFrom(magrittr,`%>%`)
-importFrom(rxode2,
-  RxODE,
-  `model<-`,
-  expit,
-  ini,
-  logit,
-  model,
-  rxRename,
-  rxSolve,
-  rxUiGet,
-  rxode,
-  rxode2
-)
-importFrom(stats,
-  qnorm,
-  setNames
-)
+importFrom(rxode2,RxODE)
+importFrom(rxode2,`model<-`)
+importFrom(rxode2,expit)
+importFrom(rxode2,ini)
+importFrom(rxode2,logit)
+importFrom(rxode2,model)
+importFrom(rxode2,rxRename)
+importFrom(rxode2,rxSolve)
+importFrom(rxode2,rxUiGet)
+importFrom(rxode2,rxode)
+importFrom(rxode2,rxode2)
+importFrom(stats,qnorm)
+importFrom(stats,setNames)
 importFrom(utils,read.csv)
 useDynLib(monolix2rx, .registration=TRUE)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -52,8 +52,6 @@ S3method(print,monolix2rxParameter)
 S3method(print,monolix2rxPk)
 S3method(print,monolix2rxPopDef)
 S3method(print,monolix2rxTask)
-S3method(rxSolve,monolix2rx)
-S3method(rxUiGet,monolixModelIwres)
 export("%>%")
 export("model<-")
 export(.getNbdoses)
@@ -71,7 +69,9 @@ export(model)
 export(monolix2rx)
 export(rxRename)
 export(rxSolve)
+export(rxSolve.monolix2rx)
 export(rxUiGet)
+export(rxUiGet.monolixModelIwres)
 export(rxode)
 export(rxode2)
 import(ggplot2)
@@ -80,18 +80,22 @@ importFrom(dparser,dparse)
 importFrom(ggplot2,autoplot)
 importFrom(lotri,lotri)
 importFrom(magrittr,`%>%`)
-importFrom(rxode2,RxODE)
-importFrom(rxode2,`model<-`)
-importFrom(rxode2,expit)
-importFrom(rxode2,ini)
-importFrom(rxode2,logit)
-importFrom(rxode2,model)
-importFrom(rxode2,rxRename)
-importFrom(rxode2,rxSolve)
-importFrom(rxode2,rxUiGet)
-importFrom(rxode2,rxode)
-importFrom(rxode2,rxode2)
-importFrom(stats,qnorm)
-importFrom(stats,setNames)
+importFrom(rxode2,
+  RxODE,
+  `model<-`,
+  expit,
+  ini,
+  logit,
+  model,
+  rxRename,
+  rxSolve,
+  rxUiGet,
+  rxode,
+  rxode2
+)
+importFrom(stats,
+  qnorm,
+  setNames
+)
 importFrom(utils,read.csv)
 useDynLib(monolix2rx, .registration=TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,20 @@
 # monolix2rx 0.0.7
 
+* `monolix2rx()`, `mlxtran()` and `mlxTxt()` gained a `dirn` argument
+  giving the directory of the Monolix project.  This makes it possible
+  to translate a project that lives outside the current working
+  directory when the mlxtran is supplied as a character vector of lines
+  (for example after editing the lines to drop a `<DATAFILE>` block), or
+  when a model text file name is relative to the project directory
+  rather than to the R session (#44).
+
+* The project directory stored on the mlxtran object is now absolute, so
+  a model read through a relative path still finds its model file, data
+  and `exportpath` results after the working directory changes.
+
+* The "model file does not exist" error now reports the directory that
+  was searched and points at `dirn=`.
+
 * Range-check the input length in all 13 `trans_*` parser entry-points
   before narrowing it for `dparse()`'s `int` buffer length.  A buffer of
   `INT_MAX` bytes or more now raises a clean R error instead of handing

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,19 +1,12 @@
 # monolix2rx 0.0.7
 
-* `monolix2rx()`, `mlxtran()` and `mlxTxt()` gained a `dirn` argument
-  giving the directory of the Monolix project.  This makes it possible
-  to translate a project that lives outside the current working
-  directory when the mlxtran is supplied as a character vector of lines
-  (for example after editing the lines to drop a `<DATAFILE>` block), or
-  when a model text file name is relative to the project directory
-  rather than to the R session (#44).
+* `monolix2rx()`, `mlxtran()` and `mlxTxt()` now have `dirn` to giving
+  the actual directory of the Monolix project, in case the project
+  moved for some reason. This makes it possible to translate project files
+  outside the project directory (#44)
 
-* The project directory stored on the mlxtran object is now absolute, so
-  a model read through a relative path still finds its model file, data
-  and `exportpath` results after the working directory changes.
+* The project directory in mlxtran is now absolute.
 
-* The "model file does not exist" error now reports the directory that
-  was searched and points at `dirn=`.
 * Support the `Monolix` 2024 file specification `file={path='data.csv'}` in
   addition to the older `file='data.csv'`; the two are equivalent.  This
   applies to the data file in `<DATAFILE> [FILEINFO]` (and

--- a/R/equation.R
+++ b/R/equation.R
@@ -238,10 +238,9 @@ as.list.monolix2rxCovEq <- as.list.monolix2rxEquation
 #' @param retFile boolean that tells `mlxTxt()` to return the file
 #'   name instead of error if the file does not exist
 #'
-#' @param dirn directory the model text file is relative to.  By
-#'   default (`NULL`) `file` is resolved from the current working
-#'   directory; this is only needed when the model file lives in a
-#'   different directory than the R session.
+#' @param dirn directory the model text file.  default (`NULL`) `file`
+#'   (working directory); only needed when the model file
+#'   lives in a different directory than the R session.
 #'
 #' @return parsed equation or file name
 #' @export
@@ -300,7 +299,9 @@ mlxTxt <- function(file, retFile=FALSE, dirn=NULL) {
     }
     if (!is.null(.monolixLib)) {
       .lines <- .monolixLib
-      .dirn <- NULL
+      # a model read from the model library has no directory of its own,
+      # so keep the project directory when one was given
+      .dirn <- dirn
     } else {
       .f <- .monolixInDirn(.mlxtranLib(file), dirn)
       if (checkmate::testFileExists(.f, "r")) {

--- a/R/equation.R
+++ b/R/equation.R
@@ -238,6 +238,11 @@ as.list.monolix2rxCovEq <- as.list.monolix2rxEquation
 #' @param retFile boolean that tells `mlxTxt()` to return the file
 #'   name instead of error if the file does not exist
 #'
+#' @param dirn directory the model text file is relative to.  By
+#'   default (`NULL`) `file` is resolved from the current working
+#'   directory; this is only needed when the model file lives in a
+#'   different directory than the R session.
+#'
 #' @return parsed equation or file name
 #' @export
 #' @author Matthew L. Fidler
@@ -256,16 +261,17 @@ as.list.monolix2rxCovEq <- as.list.monolix2rxEquation
 #' mod <- mlxTxt(file.path(pkgTheo, "oral1_1cpt_kaVCl.txt"))
 #'
 #' mod
-mlxTxt <- function(file, retFile=FALSE) {
+mlxTxt <- function(file, retFile=FALSE, dirn=NULL) {
   on.exit({
     .Call(`_monolix2rx_r_parseFree`)
   })
+  dirn <- .monolixDirn(dirn)
   if (!retFile) .mlxtranIni()
   .exit <- FALSE
   .monolixLib <- NULL
   if (length(file) > 1L) {
     .lines <- file
-    .dirn <- getwd()
+    .dirn <- if (is.null(dirn)) .monolixDirn(getwd()) else dirn
   } else {
     if (monolix2rxlixoftConnectors()) {
       if (checkmate::testCharacter(file, min.chars = 5, len=1)) {
@@ -296,10 +302,10 @@ mlxTxt <- function(file, retFile=FALSE) {
       .lines <- .monolixLib
       .dirn <- NULL
     } else {
-      .f <- .mlxtranLib(file)
+      .f <- .monolixInDirn(.mlxtranLib(file), dirn)
       if (checkmate::testFileExists(.f, "r")) {
         .lines <- suppressWarnings(readLines(.f))
-        .dirn <- dirname(.f)
+        .dirn <- .monolixDirn(dirname(.f))
       } else {
         .exit <- TRUE
       }
@@ -316,5 +322,7 @@ mlxTxt <- function(file, retFile=FALSE) {
     return(.ret)
   }
   if (retFile) return(file)
-  stop("could not find the model file", call.=FALSE)
+  stop("could not find the model file '", file,
+       "'\nif it is in another directory, give that directory with 'dirn='",
+       call.=FALSE)
 }

--- a/R/mlxtran.R
+++ b/R/mlxtran.R
@@ -280,11 +280,48 @@
   .mlxEnv$subsubsection <- sec
   .mlxEnv$isDesc <- FALSE
 }
+#' Normalize a Monolix project directory
+#'
+#' @param dirn directory (or `NULL`)
+#' @return `NULL` when `dirn` is `NULL`, otherwise the normalized
+#'   (absolute) directory.  Absolute directories keep working after the
+#'   R working directory changes, which relative directories do not.
+#' @noRd
+#' @author Matthew L. Fidler
+.monolixDirn <- function(dirn) {
+  if (is.null(dirn)) return(NULL)
+  checkmate::assertCharacter(dirn, len=1, any.missing=FALSE)
+  checkmate::assertDirectoryExists(dirn, access="r")
+  normalizePath(dirn, winslash="/", mustWork=FALSE)
+}
+
+#' Resolve a file relative to a supplied Monolix project directory
+#'
+#' @param file file name to resolve
+#' @param dirn directory the file could be relative to (or `NULL`)
+#' @return `file` resolved inside `dirn` when that exists, otherwise
+#'   `file` unchanged (which covers absolute paths, `lib:` models and
+#'   `dirn=NULL`)
+#' @noRd
+#' @author Matthew L. Fidler
+.monolixInDirn <- function(file, dirn) {
+  if (is.null(dirn)) return(file)
+  if (!checkmate::testCharacter(file, len=1, any.missing=FALSE)) return(file)
+  .f <- file.path(dirn, file)
+  if (file.exists(.f)) return(.f)
+  file
+}
+
 #' Read and parse mlxtran lines
 #'
 #' @param file mlxtran file to process
 #' @param equation parse the equation block to rxode2 (some models cannot be translated)
 #' @param update when true, try to update the parameter block to the final parameter estimates
+#' @param dirn directory of the Monolix project, used to find the files
+#'   the mlxtran refers to (model text file, data, `exportpath` results).
+#'   By default (`NULL`) this is the directory of `file`, or the current
+#'   working directory when `file` is a character vector of mlxtran
+#'   lines instead of a file name.
 #' @return mlxtran object
 #' @export
 #' @author Matthew L. Fidler
@@ -302,13 +339,24 @@
 #' mlx <- mlxtran(file.path(pkgTheo, "theophylline_project.mlxtran"))
 #'
 #' mlx
-mlxtran <- function(file, equation=FALSE, update=FALSE) {
+#'
+#' # When you edit the mlxtran lines yourself, the project directory can
+#' # no longer be guessed from a file name, so give it with `dirn`:
+#'
+#' lines <- readLines(file.path(pkgTheo, "theophylline_project.mlxtran"))
+#'
+#' mlx <- mlxtran(lines, dirn=pkgTheo)
+#'
+#' mlx
+mlxtran <- function(file, equation=FALSE, update=FALSE, dirn=NULL) {
   checkmate::assertLogical(equation, any.missing=FALSE, len=1)
   checkmate::assertLogical(update, any.missing=FALSE, len=1)
+  dirn <- .monolixDirn(dirn)
   on.exit({
     .Call(`_monolix2rx_r_parseFree`)
   })
   if (inherits(file, "monolix2rxMlxtran")) {
+    if (!is.null(dirn)) attr(file, "dirn") <- dirn
     .monolix2rx$endpointPred <- .getMonolixPreds(file)
     if (equation && !is.null(file$MODEL$LONGITUDINAL$EQUATION)) {
       file$MODEL$LONGITUDINAL$EQUATION <- .equation(file$MODEL$LONGITUDINAL$EQUATION,
@@ -322,14 +370,15 @@ mlxtran <- function(file, equation=FALSE, update=FALSE) {
   }
   if (length(file) > 1L) {
     .lines <- file
-    .dirn <- getwd()
+    .dirn <- if (is.null(dirn)) .monolixDirn(getwd()) else dirn
   } else {
+    file <- .monolixInDirn(file, dirn)
     if (checkmate::testFileExists(file, access="r", extension="txt")) {
-      return(mlxTxt(file))
+      return(mlxTxt(file, dirn=dirn))
     }
     checkmate::assertFileExists(file, access="r", extension="mlxtran")
     .lines <- suppressWarnings(readLines(file))
-    .dirn <- dirname(file)
+    .dirn <- .monolixDirn(dirname(file))
   }
   .ret <- withr::with_dir(.dirn,
                           .mlxtran(.lines, equation=equation, update=update))

--- a/R/mlxtran.R
+++ b/R/mlxtran.R
@@ -323,9 +323,7 @@
   # "/proj/tmp/m.txt")
   if (.monolixIsAbsPath(file)) return(file)
   if (substr(file, 1, 4) == "lib:") return(file)
-  .f <- file.path(dirn, file)
-  if (file.exists(.f)) return(.f)
-  file
+  file.path(dirn, file)
 }
 
 #' Read and parse mlxtran lines

--- a/R/mlxtran.R
+++ b/R/mlxtran.R
@@ -348,8 +348,8 @@
 #'
 #' mlx
 #'
-#' # When you edit the mlxtran lines, the project directory can't
-#' # be inferred anymore, so give it with `dirn`:
+#' # Sometimes the project directory can't
+#' # inferred anymore; in that case give it with `dirn`:
 #'
 #' lines <- readLines(file.path(pkgTheo, "theophylline_project.mlxtran"))
 #'

--- a/R/mlxtran.R
+++ b/R/mlxtran.R
@@ -280,12 +280,11 @@
   .mlxEnv$subsubsection <- sec
   .mlxEnv$isDesc <- FALSE
 }
-#' Normalize a Monolix project directory
+#' Normalize Monolix project directory
 #'
 #' @param dirn directory (or `NULL`)
-#' @return `NULL` when `dirn` is `NULL`, otherwise the normalized
-#'   (absolute) directory.  Absolute directories keep working after the
-#'   R working directory changes, which relative directories do not.
+#' @return `NULL` when `dirn` is `NULL`, otherwise the absolute
+#'   directory.
 #' @noRd
 #' @author Matthew L. Fidler
 .monolixDirn <- function(dirn) {
@@ -295,18 +294,35 @@
   normalizePath(dirn, winslash="/", mustWork=FALSE)
 }
 
-#' Resolve a file relative to a supplied Monolix project directory
+#' Is this file name absolute?
+#'
+#' @param file file name to check
+#' @return `TRUE` for `~`, unix absolute, Windows drive (`c:/`) and UNC
+#'   (`\\\\server`) paths
+#' @noRd
+#' @author Matthew L. Fidler
+.monolixIsAbsPath <- function(file) {
+  grepl("^(~|[/\\\\]|[A-Za-z]:[/\\\\])", file)
+}
+
+#' Resolve a file relative to Monolix project
 #'
 #' @param file file name to resolve
-#' @param dirn directory the file could be relative to (or `NULL`)
-#' @return `file` resolved inside `dirn` when that exists, otherwise
-#'   `file` unchanged (which covers absolute paths, `lib:` models and
+#' @param dirn directory  (or `NULL`)
+#' @return `file` resolved relative to `dirn` when exists, otherwise
+#'   `file` unchanged (covering absolute paths, `lib:` models and
 #'   `dirn=NULL`)
 #' @noRd
 #' @author Matthew L. Fidler
 .monolixInDirn <- function(file, dirn) {
   if (is.null(dirn)) return(file)
   if (!checkmate::testCharacter(file, len=1, any.missing=FALSE)) return(file)
+  # an absolute name and an unresolved `lib:` model are not relative to
+  # the project; joining them to `dirn` could silently pick up a
+  # same-named file (file.path("/proj", "/tmp/m.txt") reads
+  # "/proj/tmp/m.txt")
+  if (.monolixIsAbsPath(file)) return(file)
+  if (substr(file, 1, 4) == "lib:") return(file)
   .f <- file.path(dirn, file)
   if (file.exists(.f)) return(.f)
   file
@@ -317,19 +333,13 @@
 #' @param file mlxtran file to process
 #' @param equation parse the equation block to rxode2 (some models cannot be translated)
 #' @param update when true, try to update the parameter block to the final parameter estimates
-#' @param dirn directory of the Monolix project, used to find the files
-#'   the mlxtran refers to (model text file, data, `exportpath` results).
-#'   By default (`NULL`) this is the directory of `file`, or the current
-#'   working directory when `file` is a character vector of mlxtran
-#'   lines instead of a file name.
+#' @param dirn directory of the Monolix project
 #' @return mlxtran object
 #' @export
 #' @author Matthew L. Fidler
 #' @examples
+#'
 #' # First load in the model; in this case the theo model
-#' # This is modified from the Monolix demos by saving the model
-#' # File as a text file (hence you can access without model library)
-#' # setup.
 #' #
 #' # This example is also included in the monolix2rx package, so
 #' # you refer to the location with `system.file()`:
@@ -340,8 +350,8 @@
 #'
 #' mlx
 #'
-#' # When you edit the mlxtran lines yourself, the project directory can
-#' # no longer be guessed from a file name, so give it with `dirn`:
+#' # When you edit the mlxtran lines, the project directory can't
+#' # be inferred anymore, so give it with `dirn`:
 #'
 #' lines <- readLines(file.path(pkgTheo, "theophylline_project.mlxtran"))
 #'
@@ -363,8 +373,15 @@ mlxtran <- function(file, equation=FALSE, update=FALSE, dirn=NULL) {
                                                     file$MODEL$LONGITUDINAL$PK)
     }
     if (update && !is.null(file$PARAMETER)) {
-      file <- .parameterUpdate(file)
-      file <- .mlxtranCov(file)
+      # `.mlxtranCov()`/`.mlxtranSumary()` read `exportpath` relative to
+      # the working directory, so move there first; re-reading an
+      # already parsed object from elsewhere otherwise silently dropped
+      # the covariance and run information
+      # the parameters are updated first because `.mlxtranCov()` builds
+      # its jacobian from them (this matches `.mlxtranFinalize()`)
+      file <- withr::with_dir(.monolixGetPwd(file), {
+        .mlxtranCov(.parameterUpdate(file))
+      })
     }
     return(file)
   }

--- a/R/monolix2rx.R
+++ b/R/monolix2rx.R
@@ -106,7 +106,7 @@ monolix2rx <- function(mlxtran, update=TRUE, thetaMatType=c("sa", "lin"),
       if (!file.exists(.mlxtran$MODEL$LONGITUDINAL$LONGITUDINAL$file)) {
         stop("the model file '", .mlxtran$MODEL$LONGITUDINAL$LONGITUDINAL$file,
              "' does not exist in '", .monolixGetPwd(.mlxtran),
-             "'\nif it is in another directory, give that directory with 'dirn='",
+             "'\nif it is in another directory, use 'dirn='",
              "\nyou may also need to setup the model library to complete translation",
              call.=FALSE)
       }

--- a/R/monolix2rx.R
+++ b/R/monolix2rx.R
@@ -26,15 +26,12 @@
 #' @param cor Default correlation for missing correlations estimate
 #' @param theta default population estimate
 #' @param ci confidence interval for validation, by default 0.95
-#' @param sigdig number of significant digits for validation, by default 3
+#' @param sigdig number of significant digits for validation, by
+#'   default 3
 #' @param envir represents the environment used for evaluating the
 #'   corresponding rxode2 function
-#' @param dirn directory of the Monolix project, used to find the files
-#'   the mlxtran refers to (model text file, data, `exportpath`
-#'   results).  By default (`NULL`) this is the directory of the
-#'   `mlxtran` file; supply it when `mlxtran` is a character vector of
-#'   mlxtran lines (where there is no file name to take the directory
-#'   from) or when the file name is relative to another directory.
+#' @param dirn directory of the Monolix project, by default it is the
+#'   current working directory
 #' @return rxode2 model
 #' @export
 #' @author Matthew L. Fidler
@@ -64,8 +61,8 @@
 #'
 #' rx
 #'
-#' # If you edit the mlxtran lines before translating, the project
-#' # directory cannot be taken from a file name, so give it with `dirn`:
+#' # If the mlxtran lines are edited it can't detect the directory so
+#' # give it with `dirn`:
 #'
 #' lines <- readLines(file.path(pkgTheo, "theophylline_project.mlxtran"))
 #'

--- a/R/monolix2rx.R
+++ b/R/monolix2rx.R
@@ -29,6 +29,12 @@
 #' @param sigdig number of significant digits for validation, by default 3
 #' @param envir represents the environment used for evaluating the
 #'   corresponding rxode2 function
+#' @param dirn directory of the Monolix project, used to find the files
+#'   the mlxtran refers to (model text file, data, `exportpath`
+#'   results).  By default (`NULL`) this is the directory of the
+#'   `mlxtran` file; supply it when `mlxtran` is a character vector of
+#'   mlxtran lines (where there is no file name to take the directory
+#'   from) or when the file name is relative to another directory.
 #' @return rxode2 model
 #' @export
 #' @author Matthew L. Fidler
@@ -57,9 +63,18 @@
 #' rx <- monolix2rx(file.path(pkgCov, "warfarin_covariate3_project.mlxtran"))
 #'
 #' rx
+#'
+#' # If you edit the mlxtran lines before translating, the project
+#' # directory cannot be taken from a file name, so give it with `dirn`:
+#'
+#' lines <- readLines(file.path(pkgTheo, "theophylline_project.mlxtran"))
+#'
+#' rx <- monolix2rx(lines, dirn=pkgTheo)
+#'
+#' rx
 monolix2rx <- function(mlxtran, update=TRUE, thetaMatType=c("sa", "lin"),
                        sd=1.0, cor=1e-5, theta=0.5, ci=0.95, sigdig=3,
-                       envir=parent.frame()) {
+                       envir=parent.frame(), dirn=NULL) {
   if (!requireNamespace("rxode2", quietly=FALSE) ||
         !requireNamespace("lotri", quietly=FALSE)) {
     stop("'monolix2rx' requires 'rxode2' and 'lotri'",
@@ -80,18 +95,22 @@ monolix2rx <- function(mlxtran, update=TRUE, thetaMatType=c("sa", "lin"),
   .monolix2rx$iniCi <- ci
   .monolix2rx$iniSigdig <- sigdig
   thetaMatType <- match.arg(thetaMatType)
+  dirn <- .monolixDirn(dirn)
   if (length(mlxtran) == 1L && is.character(mlxtran) &&
         grepl("[.]txt$", mlxtran, ignore.case = TRUE)) {
-    .mlxtran <- mlxTxt(mlxtran)
+    .mlxtran <- mlxTxt(mlxtran, dirn=dirn)
   } else {
-    .mlxtran <- mlxtran(mlxtran, equation=TRUE, update=update)
+    .mlxtran <- mlxtran(mlxtran, equation=TRUE, update=update, dirn=dirn)
   }
   .admd <- NULL
   .cmt <- NULL
   if (!is.null(.mlxtran$MODEL$LONGITUDINAL$LONGITUDINAL$file)) {
     withr::with_dir(.monolixGetPwd(.mlxtran), {
       if (!file.exists(.mlxtran$MODEL$LONGITUDINAL$LONGITUDINAL$file)) {
-        stop("the model file '", .mlxtran$MODEL$LONGITUDINAL$LONGITUDINAL$file, "' does not exist\nyou may need to setup the model library to complete translation",
+        stop("the model file '", .mlxtran$MODEL$LONGITUDINAL$LONGITUDINAL$file,
+             "' does not exist in '", .monolixGetPwd(.mlxtran),
+             "'\nif it is in another directory, give that directory with 'dirn='",
+             "\nyou may also need to setup the model library to complete translation",
              call.=FALSE)
       }
     })

--- a/R/rxSolve.R
+++ b/R/rxSolve.R
@@ -1,12 +1,13 @@
 # This is built from buildParser.R, edit there
 #'@export
 rxSolve.monolix2rx <- function(object, params = NULL, events = NULL, 
-    inits = NULL, scale = NULL, method = "liblsoda", sigdig = NULL, atol = 1e-08, rtol = 1e-06,
-    maxsteps = 70000L, hmin = 0, hmax = NA_real_, hmaxSd = 0, 
-    hini = 0, maxordn = 12L, maxords = 5L, ..., cores, covsInterpolation = c("locf", 
-        "linear", "nocb", "midpoint"), nStud = 1L, dfSub = 0, 
-    dfObs = 0, thetaMat = NULL, ssAtol = 1e-08, ssRtol = 1e-06, 
-    minSS = 10L, maxSS = 10000L, envir = parent.frame()) {
+    inits = NULL, scale = NULL, method = "liblsoda", sigdig = NULL, 
+    atol = 1e-08, rtol = 1e-06, maxsteps = 70000L, hmin = 0, 
+    hmax = NA_real_, hmaxSd = 0, hini = 0, maxordn = 12L, maxords = 5L, 
+    order = 5L, ..., cores, covsInterpolation = c("locf", "linear", 
+        "nocb", "midpoint"), nStud = 1L, dfSub = 0, dfObs = 0, 
+    thetaMat = NULL, ssAtol = 1e-08, ssRtol = 1e-06, minSS = 10L, 
+    maxSS = 10000L, envir = parent.frame()) {
     if (missing(cores)) {
         cores <- 0L
     }
@@ -45,7 +46,7 @@ rxSolve.monolix2rx <- function(object, params = NULL, events = NULL,
                 .minfo(paste0("using thetaMat from Monolix"))
             }
             else if (nStud > 1L) {
-                warning("no thetaMat covariance is available from the Monolix import; simulating without parameter uncertainty",
+                warning("no thetaMat covariance is available from the Monolix import; simulating without parameter uncertainty", 
                   call. = FALSE)
             }
         }
@@ -88,8 +89,8 @@ rxSolve.monolix2rx <- function(object, params = NULL, events = NULL,
         inits = inits, scale = scale, method = method, sigdig = sigdig, 
         atol = atol, rtol = rtol, maxsteps = maxsteps, hmin = hmin, 
         hmax = hmax, hmaxSd = hmaxSd, hini = hini, maxordn = maxordn, 
-        maxords = maxords, ..., cores = cores, covsInterpolation = covsInterpolation, 
-        nStud = nStud, dfSub = dfSub, dfObs = dfObs, thetaMat = thetaMat, 
-        ssAtol = ssAtol, ssRtol = ssRtol, minSS = minSS, maxSS = maxSS,
-        envir = envir)
+        maxords = maxords, order = order, ..., cores = cores, 
+        covsInterpolation = covsInterpolation, nStud = nStud, 
+        dfSub = dfSub, dfObs = dfObs, thetaMat = thetaMat, ssAtol = ssAtol, 
+        ssRtol = ssRtol, minSS = minSS, maxSS = maxSS, envir = envir)
 }

--- a/man/mlxTxt.Rd
+++ b/man/mlxTxt.Rd
@@ -4,7 +4,7 @@
 \alias{mlxTxt}
 \title{Get equation block from a Monolix model txt file}
 \usage{
-mlxTxt(file, retFile = FALSE)
+mlxTxt(file, retFile = FALSE, dirn = NULL)
 }
 \arguments{
 \item{file}{string representing the model text file.  Can be
@@ -12,6 +12,11 @@ lib:fileName.txt if library setup/available}
 
 \item{retFile}{boolean that tells \code{mlxTxt()} to return the file
 name instead of error if the file does not exist}
+
+\item{dirn}{directory the model text file is relative to.  By
+default (\code{NULL}) \code{file} is resolved from the current working
+directory; this is only needed when the model file lives in a
+different directory than the R session.}
 }
 \value{
 parsed equation or file name

--- a/man/mlxTxt.Rd
+++ b/man/mlxTxt.Rd
@@ -13,10 +13,9 @@ lib:fileName.txt if library setup/available}
 \item{retFile}{boolean that tells \code{mlxTxt()} to return the file
 name instead of error if the file does not exist}
 
-\item{dirn}{directory the model text file is relative to.  By
-default (\code{NULL}) \code{file} is resolved from the current working
-directory; this is only needed when the model file lives in a
-different directory than the R session.}
+\item{dirn}{directory the model text file.  default (\code{NULL}) \code{file}
+(working directory); only needed when the model file
+lives in a different directory than the R session.}
 }
 \value{
 parsed equation or file name

--- a/man/mlxtran.Rd
+++ b/man/mlxtran.Rd
@@ -13,11 +13,7 @@ mlxtran(file, equation = FALSE, update = FALSE, dirn = NULL)
 
 \item{update}{when true, try to update the parameter block to the final parameter estimates}
 
-\item{dirn}{directory of the Monolix project, used to find the files
-the mlxtran refers to (model text file, data, \code{exportpath} results).
-By default (\code{NULL}) this is the directory of \code{file}, or the current
-working directory when \code{file} is a character vector of mlxtran
-lines instead of a file name.}
+\item{dirn}{directory of the Monolix project}
 }
 \value{
 mlxtran object
@@ -26,10 +22,8 @@ mlxtran object
 Read and parse mlxtran lines
 }
 \examples{
+
 # First load in the model; in this case the theo model
-# This is modified from the Monolix demos by saving the model
-# File as a text file (hence you can access without model library)
-# setup.
 #
 # This example is also included in the monolix2rx package, so
 # you refer to the location with `system.file()`:
@@ -40,8 +34,8 @@ mlx <- mlxtran(file.path(pkgTheo, "theophylline_project.mlxtran"))
 
 mlx
 
-# When you edit the mlxtran lines yourself, the project directory can
-# no longer be guessed from a file name, so give it with `dirn`:
+# When you edit the mlxtran lines, the project directory can't
+# be inferred anymore, so give it with `dirn`:
 
 lines <- readLines(file.path(pkgTheo, "theophylline_project.mlxtran"))
 

--- a/man/mlxtran.Rd
+++ b/man/mlxtran.Rd
@@ -34,8 +34,8 @@ mlx <- mlxtran(file.path(pkgTheo, "theophylline_project.mlxtran"))
 
 mlx
 
-# When you edit the mlxtran lines, the project directory can't
-# be inferred anymore, so give it with `dirn`:
+# Sometimes the project directory can't
+# inferred anymore; in that case give it with `dirn`:
 
 lines <- readLines(file.path(pkgTheo, "theophylline_project.mlxtran"))
 

--- a/man/mlxtran.Rd
+++ b/man/mlxtran.Rd
@@ -4,7 +4,7 @@
 \alias{mlxtran}
 \title{Read and parse mlxtran lines}
 \usage{
-mlxtran(file, equation = FALSE, update = FALSE)
+mlxtran(file, equation = FALSE, update = FALSE, dirn = NULL)
 }
 \arguments{
 \item{file}{mlxtran file to process}
@@ -12,6 +12,12 @@ mlxtran(file, equation = FALSE, update = FALSE)
 \item{equation}{parse the equation block to rxode2 (some models cannot be translated)}
 
 \item{update}{when true, try to update the parameter block to the final parameter estimates}
+
+\item{dirn}{directory of the Monolix project, used to find the files
+the mlxtran refers to (model text file, data, \code{exportpath} results).
+By default (\code{NULL}) this is the directory of \code{file}, or the current
+working directory when \code{file} is a character vector of mlxtran
+lines instead of a file name.}
 }
 \value{
 mlxtran object
@@ -31,6 +37,15 @@ Read and parse mlxtran lines
 pkgTheo <- system.file("theo", package="monolix2rx")
 
 mlx <- mlxtran(file.path(pkgTheo, "theophylline_project.mlxtran"))
+
+mlx
+
+# When you edit the mlxtran lines yourself, the project directory can
+# no longer be guessed from a file name, so give it with `dirn`:
+
+lines <- readLines(file.path(pkgTheo, "theophylline_project.mlxtran"))
+
+mlx <- mlxtran(lines, dirn=pkgTheo)
 
 mlx
 }

--- a/man/monolix2rx.Rd
+++ b/man/monolix2rx.Rd
@@ -71,8 +71,8 @@ rx <- monolix2rx(file.path(pkgCov, "warfarin_covariate3_project.mlxtran"))
 
 rx
 
-# If you edit the mlxtran lines before translating, the project
-# directory cannot be taken from a file name, so give it with `dirn`:
+# If the mlxtran lines are edited it can't detect the directory so
+# give it with `dirn`:
 
 lines <- readLines(file.path(pkgTheo, "theophylline_project.mlxtran"))
 

--- a/man/monolix2rx.Rd
+++ b/man/monolix2rx.Rd
@@ -13,7 +13,8 @@ monolix2rx(
   theta = 0.5,
   ci = 0.95,
   sigdig = 3,
-  envir = parent.frame()
+  envir = parent.frame(),
+  dirn = NULL
 )
 }
 \arguments{
@@ -40,6 +41,13 @@ variability/inter-occasion variability that are missing.}
 
 \item{envir}{represents the environment used for evaluating the
 corresponding rxode2 function}
+
+\item{dirn}{directory of the Monolix project, used to find the files
+the mlxtran refers to (model text file, data, \code{exportpath}
+results).  By default (\code{NULL}) this is the directory of the
+\code{mlxtran} file; supply it when \code{mlxtran} is a character vector of
+mlxtran lines (where there is no file name to take the directory
+from) or when the file name is relative to another directory.}
 }
 \value{
 rxode2 model
@@ -63,6 +71,15 @@ rx <- monolix2rx(file.path(pkgTheo, "theophylline_project.mlxtran"))
 pkgCov <- system.file("cov", package="monolix2rx")
 
 rx <- monolix2rx(file.path(pkgCov, "warfarin_covariate3_project.mlxtran"))
+
+rx
+
+# If you edit the mlxtran lines before translating, the project
+# directory cannot be taken from a file name, so give it with `dirn`:
+
+lines <- readLines(file.path(pkgTheo, "theophylline_project.mlxtran"))
+
+rx <- monolix2rx(lines, dirn=pkgTheo)
 
 rx
 }

--- a/man/monolix2rx.Rd
+++ b/man/monolix2rx.Rd
@@ -37,17 +37,14 @@ variability/inter-occasion variability that are missing.}
 
 \item{ci}{confidence interval for validation, by default 0.95}
 
-\item{sigdig}{number of significant digits for validation, by default 3}
+\item{sigdig}{number of significant digits for validation, by
+default 3}
 
 \item{envir}{represents the environment used for evaluating the
 corresponding rxode2 function}
 
-\item{dirn}{directory of the Monolix project, used to find the files
-the mlxtran refers to (model text file, data, \code{exportpath}
-results).  By default (\code{NULL}) this is the directory of the
-\code{mlxtran} file; supply it when \code{mlxtran} is a character vector of
-mlxtran lines (where there is no file name to take the directory
-from) or when the file name is relative to another directory.}
+\item{dirn}{directory of the Monolix project, by default it is the
+current working directory}
 }
 \value{
 rxode2 model

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -24,12 +24,12 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{ggplot2}{\code{\link[ggplot2]{autoplot}}}
+  \item{ggplot2}{\code{\link[ggplot2:autoplot]{autoplot()}}}
 
-  \item{lotri}{\code{\link[lotri]{lotri}}}
+  \item{lotri}{\code{\link[lotri:lotri]{lotri()}}}
 
-  \item{magrittr}{\code{\link[magrittr:pipe]{\%>\%}}}
+  \item{magrittr}{\code{\link[magrittr:\%>\%]{\%>\%}}}
 
-  \item{rxode2}{\code{\link[rxode2:logit]{expit}}, \code{\link[rxode2]{ini}}, \code{\link[rxode2]{logit}}, \code{\link[rxode2]{model}}, \code{\link[rxode2:model-set]{model<-}}, \code{\link[rxode2:rxode2]{rxode}}, \code{\link[rxode2:rxode2]{RxODE}}, \code{\link[rxode2]{rxode2}}, \code{\link[rxode2]{rxRename}}, \code{\link[rxode2]{rxSolve}}, \code{\link[rxode2]{rxUiGet}}}
+  \item{rxode2}{\code{\link[rxode2:expit]{expit()}}, \code{\link[rxode2:ini]{ini()}}, \code{\link[rxode2:logit]{logit()}}, \code{\link[rxode2:model]{model()}}, \code{\link[rxode2:model<-]{model<-()}}, \code{\link[rxode2:rxode]{rxode()}}, \code{\link[rxode2:RxODE]{RxODE()}}, \code{\link[rxode2:rxode2]{rxode2()}}, \code{\link[rxode2:rxRename]{rxRename()}}, \code{\link[rxode2:rxSolve]{rxSolve()}}, \code{\link[rxode2:rxUiGet]{rxUiGet()}}}
 }}
 

--- a/src/dataSettings.g.d_parser.h
+++ b/src/dataSettings.g.d_parser.h
@@ -7,7 +7,7 @@
   Available at https://github.com/jplevyak/dparser
 */
 
-#line 7 "/home/matt/src/monolix2rx/src/dataSettings.g.d_parser.c"
+#line 7 "/home/matt-fidler/src/monolix2rx-dir-44/src/dataSettings.g.d_parser.c"
 #include "dparse.h"
 
 D_Reduction d_reduction_0_dataSettings = {1, 0, NULL, NULL, 0, 0, 0, 0, -1, 0, NULL};

--- a/src/equation.g.d_parser.h
+++ b/src/equation.g.d_parser.h
@@ -7,7 +7,7 @@
   Available at https://github.com/jplevyak/dparser
 */
 
-#line 7 "/home/matt/src/monolix2rx/src/equation.g.d_parser.c"
+#line 7 "/home/matt-fidler/src/monolix2rx-dir-44/src/equation.g.d_parser.c"
 #include "dparse.h"
 
 D_Reduction d_reduction_0_equation = {1, 0, NULL, NULL, 0, 0, 0, 0, -1, 0, NULL};

--- a/src/longDef.g.d_parser.h
+++ b/src/longDef.g.d_parser.h
@@ -7,7 +7,7 @@
   Available at https://github.com/jplevyak/dparser
 */
 
-#line 7 "/home/matt/src/monolix2rx/src/longDef.g.d_parser.c"
+#line 7 "/home/matt-fidler/src/monolix2rx-dir-44/src/longDef.g.d_parser.c"
 #include "dparse.h"
 
 D_Reduction d_reduction_0_longDef = {1, 0, NULL, NULL, 0, 0, 0, 0, -1, 0, NULL};

--- a/src/longOutput.g.d_parser.h
+++ b/src/longOutput.g.d_parser.h
@@ -7,7 +7,7 @@
   Available at https://github.com/jplevyak/dparser
 */
 
-#line 7 "/home/matt/src/monolix2rx/src/longOutput.g.d_parser.c"
+#line 7 "/home/matt-fidler/src/monolix2rx-dir-44/src/longOutput.g.d_parser.c"
 #include "dparse.h"
 
 D_Reduction d_reduction_0_longOutput = {1, 0, NULL, NULL, 0, 0, 0, 0, -1, 0, NULL};

--- a/src/mlxtranContent.g.d_parser.h
+++ b/src/mlxtranContent.g.d_parser.h
@@ -7,7 +7,7 @@
   Available at https://github.com/jplevyak/dparser
 */
 
-#line 7 "/home/matt/src/monolix2rx/src/mlxtranContent.g.d_parser.c"
+#line 7 "/home/matt-fidler/src/monolix2rx-dir-44/src/mlxtranContent.g.d_parser.c"
 #include "dparse.h"
 
 D_Reduction d_reduction_0_mlxtranContent = {1, 0, NULL, NULL, 0, 0, 0, 0, -1, 0, NULL};

--- a/src/mlxtranFileinfo.g.d_parser.h
+++ b/src/mlxtranFileinfo.g.d_parser.h
@@ -7,7 +7,7 @@
   Available at https://github.com/jplevyak/dparser
 */
 
-#line 7 "/home/matt/src/monolix2rx/src/mlxtranFileinfo.g.d_parser.c"
+#line 7 "/home/matt-fidler/src/monolix2rx-dir-44/src/mlxtranFileinfo.g.d_parser.c"
 #include "dparse.h"
 
 D_Reduction d_reduction_0_mlxtranFileinfo = {1, 0, NULL, NULL, 0, 0, 0, 0, -1, 0, NULL};

--- a/src/mlxtranFit.g.d_parser.h
+++ b/src/mlxtranFit.g.d_parser.h
@@ -7,7 +7,7 @@
   Available at https://github.com/jplevyak/dparser
 */
 
-#line 7 "/home/matt/src/monolix2rx/src/mlxtranFit.g.d_parser.c"
+#line 7 "/home/matt-fidler/src/monolix2rx-dir-44/src/mlxtranFit.g.d_parser.c"
 #include "dparse.h"
 
 D_Reduction d_reduction_0_mlxtranFit = {1, 0, NULL, NULL, 0, 0, 0, 0, -1, 0, NULL};

--- a/src/mlxtranInd.g.d_parser.h
+++ b/src/mlxtranInd.g.d_parser.h
@@ -7,7 +7,7 @@
   Available at https://github.com/jplevyak/dparser
 */
 
-#line 7 "/home/matt/src/monolix2rx/src/mlxtranInd.g.d_parser.c"
+#line 7 "/home/matt-fidler/src/monolix2rx-dir-44/src/mlxtranInd.g.d_parser.c"
 #include "dparse.h"
 
 D_Reduction d_reduction_0_mlxtranInd = {1, 0, NULL, NULL, 0, 0, 0, 0, -1, 0, NULL};

--- a/src/mlxtranIndDefinition.g.d_parser.h
+++ b/src/mlxtranIndDefinition.g.d_parser.h
@@ -7,7 +7,7 @@
   Available at https://github.com/jplevyak/dparser
 */
 
-#line 7 "/home/matt/src/monolix2rx/src/mlxtranIndDefinition.g.d_parser.c"
+#line 7 "/home/matt-fidler/src/monolix2rx-dir-44/src/mlxtranIndDefinition.g.d_parser.c"
 #include "dparse.h"
 
 D_Reduction d_reduction_0_mlxtranIndDefinition = {1, 0, NULL, NULL, 0, 0, 0, 0, -1, 0, NULL};

--- a/src/mlxtranOp.g.d_parser.h
+++ b/src/mlxtranOp.g.d_parser.h
@@ -7,7 +7,7 @@
   Available at https://github.com/jplevyak/dparser
 */
 
-#line 7 "/home/matt/src/monolix2rx/src/mlxtranOp.g.d_parser.c"
+#line 7 "/home/matt-fidler/src/monolix2rx-dir-44/src/mlxtranOp.g.d_parser.c"
 #include "dparse.h"
 
 D_Reduction d_reduction_0_mlxtranOp = {1, 0, NULL, NULL, 0, 0, 0, 0, -1, 0, NULL};

--- a/src/mlxtranParameter.g.d_parser.h
+++ b/src/mlxtranParameter.g.d_parser.h
@@ -7,7 +7,7 @@
   Available at https://github.com/jplevyak/dparser
 */
 
-#line 7 "/home/matt/src/monolix2rx/src/mlxtranParameter.g.d_parser.c"
+#line 7 "/home/matt-fidler/src/monolix2rx-dir-44/src/mlxtranParameter.g.d_parser.c"
 #include "dparse.h"
 
 D_Reduction d_reduction_0_mlxtranParameter = {1, 0, NULL, NULL, 0, 0, 0, 0, -1, 0, NULL};

--- a/src/mlxtranTask.g.d_parser.h
+++ b/src/mlxtranTask.g.d_parser.h
@@ -7,7 +7,7 @@
   Available at https://github.com/jplevyak/dparser
 */
 
-#line 7 "/home/matt/src/monolix2rx/src/mlxtranTask.g.d_parser.c"
+#line 7 "/home/matt-fidler/src/monolix2rx-dir-44/src/mlxtranTask.g.d_parser.c"
 #include "dparse.h"
 
 D_Reduction d_reduction_0_mlxtranTask = {1, 0, NULL, NULL, 0, 0, 0, 0, -1, 0, NULL};

--- a/src/summaryData.g.d_parser.h
+++ b/src/summaryData.g.d_parser.h
@@ -7,7 +7,7 @@
   Available at https://github.com/jplevyak/dparser
 */
 
-#line 7 "/home/matt/src/monolix2rx/src/summaryData.g.d_parser.c"
+#line 7 "/home/matt-fidler/src/monolix2rx-dir-44/src/summaryData.g.d_parser.c"
 #include "dparse.h"
 
 D_Reduction d_reduction_0_summaryData = {1, 0, NULL, NULL, 0, 0, 0, 0, -1, 0, NULL};

--- a/tests/testthat/test-dirn.R
+++ b/tests/testthat/test-dirn.R
@@ -62,9 +62,16 @@ test_that("'dirn' never captures an absolute or 'lib:' file name", {
   # a relative name that exists under 'dirn' is resolved there
   expect_equal(.monolixInDirn(file.path("tmp", "decoy.txt"), .d),
                file.path(.d, "tmp", "decoy.txt"))
-  # a relative name that does not exist under 'dirn' is left alone
-  expect_equal(.monolixInDirn("nope.txt", .d), "nope.txt")
+  # a relative name that does not exist under 'dirn' is not allowed to
+  # fall back to a same-named file in the working directory
+  expect_equal(.monolixInDirn("nope.txt", .d), file.path(.d, "nope.txt"))
   expect_equal(.monolixInDirn("nope.txt", NULL), "nope.txt")
+
+  withr::with_dir(.real, {
+    writeLines("decoy", "decoy.txt")
+    expect_error(mlxTxt("decoy.txt", dirn = .d), "decoy.txt")
+    expect_error(mlxtran("decoy.mlxtran", dirn = .d))
+  })
 })
 
 test_that("re-reading a parsed mlxtran object reads its results directory", {

--- a/tests/testthat/test-dirn.R
+++ b/tests/testthat/test-dirn.R
@@ -9,6 +9,11 @@ test_that("mlxtran() finds the project files when 'dirn' is given (issue #44)", 
     # directory, so the model text file cannot be found
     expect_error(monolix2rx(.lines, update = FALSE),
                  "does not exist")
+    # the error names the directory searched and points at 'dirn='
+    expect_error(monolix2rx(.lines, update = FALSE),
+                 normalizePath(tempdir(), winslash = "/"), fixed = TRUE)
+    expect_error(monolix2rx(.lines, update = FALSE), "dirn=", fixed = TRUE)
+    expect_error(mlxTxt("oral1_1cpt_kaVCl.txt"), "dirn=", fixed = TRUE)
 
     .mlx <- mlxtran(.lines, dirn = .theo)
     expect_equal(normalizePath(attr(.mlx, "dirn"), winslash = "/"),
@@ -36,6 +41,48 @@ test_that("'dirn' resolves a relative mlxtran/txt file name", {
                     dirn = tempdir())
     expect_equal(normalizePath(attr(.mlx, "dirn"), winslash = "/"),
                  normalizePath(.theo, winslash = "/"))
+  })
+})
+
+test_that("'dirn' never captures an absolute or 'lib:' file name", {
+  # file.path("/proj", "/tmp/m.txt") is "/proj//tmp/m.txt", so a
+  # same-named file under 'dirn' could silently win over the absolute
+  # name the user asked for
+  .d <- file.path(tempdir(), "dirn-abs")
+  dir.create(file.path(.d, "tmp"), recursive = TRUE, showWarnings = FALSE)
+  writeLines("decoy", file.path(.d, "tmp", "decoy.txt"))
+  .real <- file.path(tempdir(), "tmp-real")
+  dir.create(.real, recursive = TRUE, showWarnings = FALSE)
+
+  expect_equal(.monolixInDirn("/tmp/decoy.txt", .d), "/tmp/decoy.txt")
+  expect_equal(.monolixInDirn("~/decoy.txt", .d), "~/decoy.txt")
+  expect_equal(.monolixInDirn("c:/tmp/decoy.txt", .d), "c:/tmp/decoy.txt")
+  expect_equal(.monolixInDirn("\\\\srv\\decoy.txt", .d), "\\\\srv\\decoy.txt")
+  expect_equal(.monolixInDirn("lib:decoy.txt", .d), "lib:decoy.txt")
+  # a relative name that exists under 'dirn' is resolved there
+  expect_equal(.monolixInDirn(file.path("tmp", "decoy.txt"), .d),
+               file.path(.d, "tmp", "decoy.txt"))
+  # a relative name that does not exist under 'dirn' is left alone
+  expect_equal(.monolixInDirn("nope.txt", .d), "nope.txt")
+  expect_equal(.monolixInDirn("nope.txt", NULL), "nope.txt")
+})
+
+test_that("re-reading a parsed mlxtran object reads its results directory", {
+  .theo <- system.file("theo", package = "monolix2rx")
+  skip_if_not(dir.exists(.theo))
+
+  .mlx <- mlxtran(file.path(.theo, "theophylline_project.mlxtran"))
+  expect_true(inherits(attr(.mlx, "covLinUntransformed"), "matrix"))
+
+  # `.mlxtranCov()`/`.mlxtranSumary()` read `exportpath` relative to the
+  # working directory; updating from elsewhere used to silently drop the
+  # covariance and the run information
+  attr(.mlx, "covLinUntransformed") <- NULL
+  withr::with_dir(tempdir(), {
+    .upd <- mlxtran(.mlx, update = TRUE)
+    expect_true(inherits(attr(.upd, "covLinUntransformed"), "matrix"))
+    # summary.txt is read from the project too
+    expect_equal(attr(.upd, "version"), attr(.mlx, "version"))
   })
 })
 

--- a/tests/testthat/test-dirn.R
+++ b/tests/testthat/test-dirn.R
@@ -4,14 +4,15 @@ test_that("mlxtran() finds the project files when 'dirn' is given (issue #44)", 
 
   .lines <- readLines(file.path(.theo, "theophylline_project.mlxtran"))
 
-  withr::with_dir(tempdir(), {
+  .wd <- withr::local_tempdir()
+  withr::with_dir(.wd, {
     # without 'dirn' the mlxtran lines are resolved against the working
     # directory, so the model text file cannot be found
     expect_error(monolix2rx(.lines, update = FALSE),
                  "does not exist")
     # the error names the directory searched and points at 'dirn='
     expect_error(monolix2rx(.lines, update = FALSE),
-                 normalizePath(tempdir(), winslash = "/"), fixed = TRUE)
+                 normalizePath(.wd, winslash = "/"), fixed = TRUE)
     expect_error(monolix2rx(.lines, update = FALSE), "dirn=", fixed = TRUE)
     expect_error(mlxTxt("oral1_1cpt_kaVCl.txt"), "dirn=", fixed = TRUE)
 
@@ -29,7 +30,8 @@ test_that("'dirn' resolves a relative mlxtran/txt file name", {
   .theo <- system.file("theo", package = "monolix2rx")
   skip_if_not(dir.exists(.theo))
 
-  withr::with_dir(tempdir(), {
+  .wd <- withr::local_tempdir()
+  withr::with_dir(.wd, {
     .mlx <- mlxtran("theophylline_project.mlxtran", dirn = .theo)
     expect_true(inherits(.mlx, "monolix2rxMlxtran"))
 
@@ -85,7 +87,8 @@ test_that("re-reading a parsed mlxtran object reads its results directory", {
   # working directory; updating from elsewhere used to silently drop the
   # covariance and the run information
   attr(.mlx, "covLinUntransformed") <- NULL
-  withr::with_dir(tempdir(), {
+  .wd <- withr::local_tempdir()
+  withr::with_dir(.wd, {
     .upd <- mlxtran(.mlx, update = TRUE)
     expect_true(inherits(attr(.upd, "covLinUntransformed"), "matrix"))
     # summary.txt is read from the project too
@@ -102,24 +105,44 @@ test_that("the stored project directory survives a change of working directory",
                                             "theophylline_project.mlxtran")))
   # the directory is stored absolute, so it still points at the project
   # after the working directory moves elsewhere
-  withr::with_dir(tempdir(), {
+  .wd <- withr::local_tempdir()
+  withr::with_dir(.wd, {
     expect_equal(normalizePath(.monolixGetPwd(.mlx), winslash = "/"),
                  normalizePath(.theo, winslash = "/"))
   })
 })
 
 test_that("'dirn' is checked", {
+  # match the assertion itself: `mlxTxt()`/`monolix2rx()` also mention
+  # 'dirn=' when they cannot find a file, so a looser pattern would pass
+  # even with the check removed
   expect_error(mlxtran("foo.mlxtran", dirn = file.path(tempdir(), "does-not-exist")),
-               "dirn")
+               "Assertion on 'dirn' failed: Directory", fixed = TRUE)
   expect_error(mlxtran("foo.mlxtran", dirn = c("a", "b")),
-               "dirn")
-  expect_error(mlxtran("foo.mlxtran", dirn = NA_character_), "dirn")
-  expect_error(mlxtran("foo.mlxtran", dirn = 1L), "dirn")
-  expect_error(mlxTxt("foo.txt", dirn = 1L), "dirn")
-  expect_error(monolix2rx("foo.txt", dirn = 1L), "dirn")
+               "Assertion on 'dirn' failed: Must have length 1", fixed = TRUE)
+  expect_error(mlxtran("foo.mlxtran", dirn = NA_character_),
+               "Assertion on 'dirn' failed: Contains missing values", fixed = TRUE)
+  expect_error(mlxtran("foo.mlxtran", dirn = 1L),
+               "Assertion on 'dirn' failed: Must be of type 'character'", fixed = TRUE)
+  expect_error(mlxTxt("foo.txt", dirn = 1L),
+               "Assertion on 'dirn' failed: Must be of type 'character'", fixed = TRUE)
+  expect_error(monolix2rx("foo.txt", dirn = 1L),
+               "Assertion on 'dirn' failed: Must be of type 'character'", fixed = TRUE)
+
   expect_null(.monolixDirn(NULL))
-  expect_equal(.monolixDirn(tempdir()),
-               normalizePath(tempdir(), winslash = "/", mustWork = FALSE))
+  # the contract is relative -> absolute, checked against a directory
+  # known independently of how .monolixDirn() computes it
+  .theo <- system.file("theo", package = "monolix2rx")
+  skip_if_not(dir.exists(.theo))
+  withr::with_dir(.theo, {
+    expect_equal(.monolixDirn("."),
+                 normalizePath(.theo, winslash = "/", mustWork = FALSE))
+  })
+  withr::with_dir(dirname(.theo), {
+    expect_equal(.monolixDirn(basename(.theo)),
+                 normalizePath(.theo, winslash = "/", mustWork = FALSE))
+  })
+  expect_true(.monolixIsAbsPath(.monolixDirn(".")))
 })
 
 test_that(".monolixInDirn() only resolves a single file name", {
@@ -165,7 +188,8 @@ test_that("a model text file is routed through mlxTxt() with 'dirn'", {
   .theo <- system.file("theo", package = "monolix2rx")
   skip_if_not(dir.exists(.theo))
 
-  withr::with_dir(tempdir(), {
+  .wd <- withr::local_tempdir()
+  withr::with_dir(.wd, {
     # mlxtran() hands a .txt file to mlxTxt()
     .mlx <- mlxtran(file.path(.theo, "oral1_1cpt_kaVCl.txt"))
     expect_true(inherits(.mlx, "monolix2rxMlxtran"))
@@ -194,8 +218,9 @@ test_that("mlxTxt() keeps 'dirn' for a model read from the model library", {
     monolix2rxGetLibraryModelContent = function(filename) {
       paste(.lines, collapse = "\n")
     })
+  .old <- .monolix2rx$lixoftConnectors
+  on.exit(.monolix2rx$lixoftConnectors <- .old, add = TRUE)
   .monolix2rx$lixoftConnectors <- TRUE
-  on.exit(.monolix2rx$lixoftConnectors <- NA, add = TRUE)
 
   .mlx <- mlxTxt("lib:oral1_1cpt_kaVCl.txt", dirn = .d)
   expect_true(inherits(.mlx, "monolix2rxMlxtran"))
@@ -259,8 +284,9 @@ test_that("mlxTxt() initializes lixoftConnectors on the first 'lib:' model", {
     monolix2rxGetLibraryModelContent = function(filename) {
       paste(.lines, collapse = "\n")
     })
+  .old <- .monolix2rx$lixoftConnectors
+  on.exit(.monolix2rx$lixoftConnectors <- .old, add = TRUE)
   .monolix2rx$lixoftConnectors <- NA
-  on.exit(.monolix2rx$lixoftConnectors <- NA, add = TRUE)
 
   .mlx <- mlxTxt("lib:oral1_1cpt_kaVCl.txt", dirn = .d)
   expect_true(inherits(.mlx, "monolix2rxMlxtran"))
@@ -268,7 +294,8 @@ test_that("mlxTxt() initializes lixoftConnectors on the first 'lib:' model", {
 })
 
 test_that("mlxTxt() warns when lixoftConnectors cannot be initialized", {
-  .d <- normalizePath(tempdir(), winslash = "/", mustWork = FALSE)
+  .d <- withr::local_tempdir()
+  withr::local_options(monolix2rx.library = NULL)
 
   testthat::local_mocked_bindings(
     monolix2rxlixoftConnectors = function() TRUE,
@@ -279,8 +306,9 @@ test_that("mlxTxt() warns when lixoftConnectors cannot be initialized", {
     monolix2rxGetLibraryModelContent = function(filename) {
       stop("unreachable without a connector")
     })
+  .old <- .monolix2rx$lixoftConnectors
+  on.exit(.monolix2rx$lixoftConnectors <- .old, add = TRUE)
   .monolix2rx$lixoftConnectors <- NA
-  on.exit(.monolix2rx$lixoftConnectors <- NA, add = TRUE)
 
   # collect every warning so the unrelated model library warning from
   # .mlxtranLib() does not escape the test
@@ -296,14 +324,18 @@ test_that("mlxTxt() warns when lixoftConnectors cannot be initialized", {
 })
 
 test_that("mlxTxt() falls back when the model library cannot be read", {
-  .d <- normalizePath(tempdir(), winslash = "/", mustWork = FALSE)
+  .d <- withr::local_tempdir()
+  # a machine with a real model library set could otherwise expand the
+  # name and never reach the fallback under test
+  withr::local_options(monolix2rx.library = NULL)
   testthat::local_mocked_bindings(
     monolix2rxlixoftConnectors = function() TRUE,
     monolix2rxGetLibraryModelContent = function(filename) {
       stop("no such library model")
     })
+  .old <- .monolix2rx$lixoftConnectors
+  on.exit(.monolix2rx$lixoftConnectors <- .old, add = TRUE)
   .monolix2rx$lixoftConnectors <- TRUE
-  on.exit(.monolix2rx$lixoftConnectors <- NA, add = TRUE)
 
   # .mlxtranLib() warns about the model library when it cannot expand the
   # name; the fallback behavior is what is under test here

--- a/tests/testthat/test-dirn.R
+++ b/tests/testthat/test-dirn.R
@@ -1,0 +1,62 @@
+test_that("mlxtran() finds the project files when 'dirn' is given (issue #44)", {
+  .theo <- system.file("theo", package = "monolix2rx")
+  skip_if_not(dir.exists(.theo))
+
+  .lines <- readLines(file.path(.theo, "theophylline_project.mlxtran"))
+
+  withr::with_dir(tempdir(), {
+    # without 'dirn' the mlxtran lines are resolved against the working
+    # directory, so the model text file cannot be found
+    expect_error(monolix2rx(.lines, update = FALSE),
+                 "does not exist")
+
+    .mlx <- mlxtran(.lines, dirn = .theo)
+    expect_equal(normalizePath(attr(.mlx, "dirn"), winslash = "/"),
+                 normalizePath(.theo, winslash = "/"))
+    expect_true(!is.null(.mlx$MODEL$LONGITUDINAL$EQUATION))
+
+    .ui <- monolix2rx(.lines, dirn = .theo, update = FALSE)
+    expect_true(inherits(.ui, "monolix2rx"))
+  })
+})
+
+test_that("'dirn' resolves a relative mlxtran/txt file name", {
+  .theo <- system.file("theo", package = "monolix2rx")
+  skip_if_not(dir.exists(.theo))
+
+  withr::with_dir(tempdir(), {
+    .mlx <- mlxtran("theophylline_project.mlxtran", dirn = .theo)
+    expect_true(inherits(.mlx, "monolix2rxMlxtran"))
+
+    .txt <- mlxTxt("oral1_1cpt_kaVCl.txt", dirn = .theo)
+    expect_true(inherits(.txt, "monolix2rxMlxtran"))
+
+    # an absolute file name still wins over 'dirn'
+    .mlx <- mlxtran(file.path(.theo, "theophylline_project.mlxtran"),
+                    dirn = tempdir())
+    expect_equal(normalizePath(attr(.mlx, "dirn"), winslash = "/"),
+                 normalizePath(.theo, winslash = "/"))
+  })
+})
+
+test_that("the stored project directory survives a change of working directory", {
+  .theo <- system.file("theo", package = "monolix2rx")
+  skip_if_not(dir.exists(.theo))
+
+  .mlx <- withr::with_dir(dirname(.theo),
+                          mlxtran(file.path(basename(.theo),
+                                            "theophylline_project.mlxtran")))
+  # the directory is stored absolute, so it still points at the project
+  # after the working directory moves elsewhere
+  withr::with_dir(tempdir(), {
+    expect_equal(normalizePath(.monolixGetPwd(.mlx), winslash = "/"),
+                 normalizePath(.theo, winslash = "/"))
+  })
+})
+
+test_that("'dirn' is checked", {
+  expect_error(mlxtran("foo.mlxtran", dirn = file.path(tempdir(), "does-not-exist")),
+               "dirn")
+  expect_error(mlxtran("foo.mlxtran", dirn = c("a", "b")),
+               "dirn")
+})

--- a/tests/testthat/test-dirn.R
+++ b/tests/testthat/test-dirn.R
@@ -113,4 +113,202 @@ test_that("'dirn' is checked", {
                "dirn")
   expect_error(mlxtran("foo.mlxtran", dirn = c("a", "b")),
                "dirn")
+  expect_error(mlxtran("foo.mlxtran", dirn = NA_character_), "dirn")
+  expect_error(mlxtran("foo.mlxtran", dirn = 1L), "dirn")
+  expect_error(mlxTxt("foo.txt", dirn = 1L), "dirn")
+  expect_error(monolix2rx("foo.txt", dirn = 1L), "dirn")
+  expect_null(.monolixDirn(NULL))
+  expect_equal(.monolixDirn(tempdir()),
+               normalizePath(tempdir(), winslash = "/", mustWork = FALSE))
+})
+
+test_that(".monolixInDirn() only resolves a single file name", {
+  .d <- tempdir()
+  # anything that is not one non-missing string is passed through so the
+  # caller reports it, rather than being turned into a path here
+  expect_equal(.monolixInDirn(c("a.txt", "b.txt"), .d), c("a.txt", "b.txt"))
+  expect_equal(.monolixInDirn(character(0), .d), character(0))
+  expect_equal(.monolixInDirn(NA_character_, .d), NA_character_)
+  expect_equal(.monolixInDirn(1L, .d), 1L)
+})
+
+test_that(".monolixIsAbsPath() classifies unix and windows names", {
+  expect_true(.monolixIsAbsPath("/tmp/m.txt"))
+  expect_true(.monolixIsAbsPath("~/m.txt"))
+  expect_true(.monolixIsAbsPath("c:/proj/m.txt"))
+  expect_true(.monolixIsAbsPath("C:\\proj\\m.txt"))
+  expect_true(.monolixIsAbsPath("\\\\srv\\share\\m.txt"))
+  expect_false(.monolixIsAbsPath("m.txt"))
+  expect_false(.monolixIsAbsPath("sub/m.txt"))
+  expect_false(.monolixIsAbsPath("./m.txt"))
+  expect_false(.monolixIsAbsPath("../m.txt"))
+  # a drive-relative name is not absolute
+  expect_false(.monolixIsAbsPath("c:m.txt"))
+})
+
+test_that("'dirn' overrides the directory of an already parsed object", {
+  .theo <- system.file("theo", package = "monolix2rx")
+  skip_if_not(dir.exists(.theo))
+
+  .mlx <- mlxtran(file.path(.theo, "theophylline_project.mlxtran"))
+  .d <- normalizePath(tempdir(), winslash = "/", mustWork = FALSE)
+
+  .moved <- mlxtran(.mlx, dirn = .d)
+  expect_equal(attr(.moved, "dirn"), .d)
+  expect_equal(normalizePath(.monolixGetPwd(.moved), winslash = "/"), .d)
+  # the original is untouched
+  expect_equal(normalizePath(attr(.mlx, "dirn"), winslash = "/"),
+               normalizePath(.theo, winslash = "/"))
+})
+
+test_that("a model text file is routed through mlxTxt() with 'dirn'", {
+  .theo <- system.file("theo", package = "monolix2rx")
+  skip_if_not(dir.exists(.theo))
+
+  withr::with_dir(tempdir(), {
+    # mlxtran() hands a .txt file to mlxTxt()
+    .mlx <- mlxtran(file.path(.theo, "oral1_1cpt_kaVCl.txt"))
+    expect_true(inherits(.mlx, "monolix2rxMlxtran"))
+    expect_equal(normalizePath(attr(.mlx, "dirn"), winslash = "/"),
+                 normalizePath(.theo, winslash = "/"))
+
+    .mlx <- mlxtran("oral1_1cpt_kaVCl.txt", dirn = .theo)
+    expect_equal(normalizePath(attr(.mlx, "dirn"), winslash = "/"),
+                 normalizePath(.theo, winslash = "/"))
+
+    # monolix2rx() takes the same route for a .txt model
+    .ui <- monolix2rx("oral1_1cpt_kaVCl.txt", dirn = .theo)
+    expect_true(inherits(.ui, "monolix2rx"))
+  })
+})
+
+test_that("mlxTxt() keeps 'dirn' for a model read from the model library", {
+  .lines <- readLines(file.path(system.file("theo", package = "monolix2rx"),
+                                "oral1_1cpt_kaVCl.txt"))
+  .d <- normalizePath(tempdir(), winslash = "/", mustWork = FALSE)
+
+  # a `lib:` model has no directory of its own, so the project directory
+  # given by the caller has to survive
+  testthat::local_mocked_bindings(
+    monolix2rxlixoftConnectors = function() TRUE,
+    monolix2rxGetLibraryModelContent = function(filename) {
+      paste(.lines, collapse = "\n")
+    })
+  .monolix2rx$lixoftConnectors <- TRUE
+  on.exit(.monolix2rx$lixoftConnectors <- NA, add = TRUE)
+
+  .mlx <- mlxTxt("lib:oral1_1cpt_kaVCl.txt", dirn = .d)
+  expect_true(inherits(.mlx, "monolix2rxMlxtran"))
+  expect_equal(attr(.mlx, "dirn"), .d)
+
+  # without 'dirn' there is no directory to record
+  .mlx <- mlxTxt("lib:oral1_1cpt_kaVCl.txt")
+  expect_null(attr(.mlx, "dirn"))
+})
+
+test_that("mlxTxt() takes 'dirn' when it is handed model lines", {
+  .theo <- system.file("theo", package = "monolix2rx")
+  skip_if_not(dir.exists(.theo))
+
+  .lines <- readLines(file.path(.theo, "oral1_1cpt_kaVCl.txt"))
+  .d <- normalizePath(tempdir(), winslash = "/", mustWork = FALSE)
+
+  .mlx <- mlxTxt(.lines, dirn = .d)
+  expect_true(inherits(.mlx, "monolix2rxMlxtran"))
+  expect_equal(attr(.mlx, "dirn"), .d)
+
+  # with no 'dirn' the lines are taken to describe the working directory
+  withr::with_dir(.theo, {
+    .mlx <- mlxTxt(.lines)
+    expect_equal(normalizePath(attr(.mlx, "dirn"), winslash = "/"),
+                 normalizePath(.theo, winslash = "/"))
+  })
+})
+
+test_that("mlxTxt() only consults the model library for a 'lib:' name", {
+  .theo <- system.file("theo", package = "monolix2rx")
+  skip_if_not(dir.exists(.theo))
+
+  .d <- file.path(tempdir(), "short-name")
+  dir.create(.d, showWarnings = FALSE)
+  # a name too short to carry a "lib:" prefix skips the library lookup
+  file.copy(file.path(.theo, "oral1_1cpt_kaVCl.txt"), file.path(.d, "m.t"),
+            overwrite = TRUE)
+
+  testthat::local_mocked_bindings(
+    monolix2rxlixoftConnectors = function() TRUE,
+    monolix2rxGetLibraryModelContent = function(filename) {
+      stop("the model library must not be consulted here")
+    })
+
+  .mlx <- mlxTxt("m.t", dirn = .d)
+  expect_true(inherits(.mlx, "monolix2rxMlxtran"))
+  expect_equal(normalizePath(attr(.mlx, "dirn"), winslash = "/"),
+               normalizePath(.d, winslash = "/"))
+})
+
+test_that("mlxTxt() initializes lixoftConnectors on the first 'lib:' model", {
+  .lines <- readLines(file.path(system.file("theo", package = "monolix2rx"),
+                                "oral1_1cpt_kaVCl.txt"))
+  .d <- normalizePath(tempdir(), winslash = "/", mustWork = FALSE)
+
+  testthat::local_mocked_bindings(
+    monolix2rxlixoftConnectors = function() TRUE,
+    monolix2rxInitializeLixoftConnectors = function(software = "monolix",
+                                                    force = TRUE) TRUE,
+    monolix2rxGetLibraryModelContent = function(filename) {
+      paste(.lines, collapse = "\n")
+    })
+  .monolix2rx$lixoftConnectors <- NA
+  on.exit(.monolix2rx$lixoftConnectors <- NA, add = TRUE)
+
+  .mlx <- mlxTxt("lib:oral1_1cpt_kaVCl.txt", dirn = .d)
+  expect_true(inherits(.mlx, "monolix2rxMlxtran"))
+  expect_true(.monolix2rx$lixoftConnectors)
+})
+
+test_that("mlxTxt() warns when lixoftConnectors cannot be initialized", {
+  .d <- normalizePath(tempdir(), winslash = "/", mustWork = FALSE)
+
+  testthat::local_mocked_bindings(
+    monolix2rxlixoftConnectors = function() TRUE,
+    monolix2rxInitializeLixoftConnectors = function(software = "monolix",
+                                                    force = TRUE) {
+      stop("lixoftConnectors is not installed")
+    },
+    monolix2rxGetLibraryModelContent = function(filename) {
+      stop("unreachable without a connector")
+    })
+  .monolix2rx$lixoftConnectors <- NA
+  on.exit(.monolix2rx$lixoftConnectors <- NA, add = TRUE)
+
+  # collect every warning so the unrelated model library warning from
+  # .mlxtranLib() does not escape the test
+  .warn <- character(0)
+  withCallingHandlers(
+    try(mlxTxt("lib:oral1_1cpt_kaVCl.txt", dirn = .d), silent = TRUE),
+    warning = function(w) {
+      .warn <<- c(.warn, conditionMessage(w))
+      invokeRestart("muffleWarning")
+    })
+  expect_true(any(grepl("cannot be initialized", .warn)))
+  expect_false(.monolix2rx$lixoftConnectors)
+})
+
+test_that("mlxTxt() falls back when the model library cannot be read", {
+  .d <- normalizePath(tempdir(), winslash = "/", mustWork = FALSE)
+  testthat::local_mocked_bindings(
+    monolix2rxlixoftConnectors = function() TRUE,
+    monolix2rxGetLibraryModelContent = function(filename) {
+      stop("no such library model")
+    })
+  .monolix2rx$lixoftConnectors <- TRUE
+  on.exit(.monolix2rx$lixoftConnectors <- NA, add = TRUE)
+
+  # .mlxtranLib() warns about the model library when it cannot expand the
+  # name; the fallback behavior is what is under test here
+  expect_error(suppressWarnings(mlxTxt("lib:not-a-model.txt", dirn = .d)),
+               "dirn=", fixed = TRUE)
+  expect_equal(suppressWarnings(mlxTxt("lib:not-a-model.txt", retFile = TRUE)),
+               "lib:not-a-model.txt")
 })


### PR DESCRIPTION
Fixes #44

## Problem

`mlxtran()` took the Monolix project directory from the file name it was
given, and fell back to `getwd()` when it was handed a character vector
of mlxtran *lines* instead of a file name. So this — the case in the
issue, where the lines are edited first to drop the `<DATAFILE>` info —
looked for everything in the R session's directory:

```r
txt <- readLines("~/pmx/.../OVCAR3_TV_ECI830_Gomp_LK.mlxtran")
monolix2rx(txt[-(2:8)], update = TRUE)
#> Error: the model file 'TGI_Gompertz_LK_mono.txt' does not exist
#> you may need to setup the model library to complete translation
```

Reproducible with the package's own theophylline project from any other
working directory.

## Fix

`monolix2rx()`, `mlxtran()` and `mlxTxt()` gained a `dirn` argument
naming the project directory:

```r
monolix2rx(txt[-(2:8)], update = TRUE, dirn = "~/pmx/.../models")
```

It is used for everything the mlxtran refers to — the model text file,
the data, and the `exportpath` results — and also resolves a *relative*
model/mlxtran file name against the project directory rather than the R
session.

Two smaller related fixes:

- the directory stored on the mlxtran object is now normalized to an
  absolute path, so a project read through a relative path still finds
  its files after the working directory changes;
- the "model file does not exist" error names the directory that was
  searched and points at `dirn=`.

## Testing

- New `tests/testthat/test-dirn.R` covering the issue's failure mode,
  relative file names, the absolute-directory guarantee across a
  `setwd()`, and argument checking.
- Full suite: `[ FAIL 0 | WARN 2 | SKIP 3 | PASS 495 ]` (skips are
  `lixoftConnectors` not being installed).
- Examples for all three documented functions run.